### PR TITLE
fixed bug where when user creates a partition will all empty fields, …

### DIFF
--- a/app/controllers/admin/action_pages_controller.rb
+++ b/app/controllers/admin/action_pages_controller.rb
@@ -167,7 +167,7 @@ class Admin::ActionPagesController < Admin::ApplicationController
       @actionPage.tweet.tweet_targets.push(target)
     end
   end
-  
+
   def default_values
     self.email_text ||= "default value"
   end

--- a/app/views/admin/action_pages/_panel_analytics.html.erb
+++ b/app/views/admin/action_pages/_panel_analytics.html.erb
@@ -95,7 +95,7 @@
           ) %>
         <% end %>
 
-        <% if @actionPage.enable_petition? && @actionPage.petition %>
+        <% if @actionPage.enable_petition? && @actionPage.petition && @actionPage.petition.persisted? %>
           <h3 class=clearfix>
             Petition Tool
             <%= link_to 'Download CSV',


### PR DESCRIPTION
…it's invalid thus is nil, yet the analytics page tries to create a csv path out of it, crashing view