### PR TITLE
Fixing civicrm key

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -4,7 +4,7 @@ class SubscriptionsController < ApplicationController
     email = params[:subscription][:email]
     if EmailValidator.valid?(email)
       params[:subscription][:opt_in] = false
-      CiviCRM::subscribe params[:subscription] unless Rails.env == 'test'
+      CiviCRM::subscribe params[:subscription]
 
       update_user_data(email: email)
       render json: {}

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,7 +21,7 @@
           <div class="alert alert-warning">
             <%= form_for current_user, html: { method: :put , class: :enable_logging } do |f| %>
               <%= f.hidden_field(:record_activity, :value => 'true') %>
-              It looks like activity recording isn't enabled, so we don't store a record which actions you've taken. 
+              It looks like activity recording isn't enabled, so we don't store a record which actions you've taken.
               <%= submit_tag "Enable activity logging", class: 'link-button' %> to see your activity here.
             <% end -%>
           </div>
@@ -72,25 +72,25 @@
           <div class="quad-1">
             <span>
               <%= current_user.events.actions.calls.count %>
-            </span> 
+            </span>
             call<%= "s" if current_user.events.actions.calls.count != 1 %>
           </div>
           <div class="quad-2">
             <span>
               <%= current_user.events.actions.signatures.count %>
-            </span> 
+            </span>
             petition<%= "s" if current_user.events.actions.signatures.count != 1 -%>
           </div>
           <div class="quad-3">
             <span>
               <%= current_user.events.actions.emails.count %>
-            </span> 
+            </span>
             email<%= "s" if current_user.events.actions.emails.count != 1 -%>
           </div>
           <div class="quad-4">
             <span>
               <%= current_user.events.actions.count -%>
-            </span> 
+            </span>
             total
           </div>
         </div>
@@ -186,7 +186,7 @@
       <% if current_user.contact_id! -%>
         <p>Click below to change your EFF newsletter subscriptions.</p>
         <%= link_to "Edit subscriptions",
-          "#{SUPPORTERS_API_HOST}/update-preferences?id=#{current_user.contact_id}",
+          "#{Rails.application.secrets.supporters['host']}/update-preferences?id=#{current_user.contact_id}",
           :class => 'btn btn-sm btn-red-outline edit-settings' -%>
       <% else -%>
         <form action="https://supporters.eff.org/" method="post" id="eff-supporters-library-account-form" accept-charset="UTF-8" _lpchecked="1">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,8 +46,4 @@ Actioncenter::Application.configure do
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
   config.assets.debug = false
-  SUPPORTERS_API_KEY = Rails.application.secrets.supporters['api_key']
-  SUPPORTERS_API_HOST = Rails.application.secrets.supporters['host']
-  SUPPORTERS_API_PATH = Rails.application.secrets.supporters['path']
-  SUPPORTERS_API_URL = "#{SUPPORTERS_API_HOST}/#{SUPPORTERS_API_PATH}"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,11 +96,6 @@ Actioncenter::Application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-  SUPPORTERS_API_KEY = Rails.application.secrets.supporters['api_key']
-  SUPPORTERS_API_HOST = Rails.application.secrets.supporters['host']
-  SUPPORTERS_API_PATH = Rails.application.secrets.supporters['path']
-  SUPPORTERS_API_URL = "#{SUPPORTERS_API_HOST}/#{SUPPORTERS_API_PATH}"
-  #{
 
   # Enable basic auth if the secret is set to true.
   # At EFF we use this to prevent access to our Heroku staging access by setting the enable_basic_auth to 'true' and setting the basic_auth_username and basic_auth_password env variables.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -96,11 +96,6 @@ Actioncenter::Application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-  SUPPORTERS_API_KEY = Rails.application.secrets.supporters['api_key']
-  SUPPORTERS_API_HOST = Rails.application.secrets.supporters['host']
-  SUPPORTERS_API_PATH = Rails.application.secrets.supporters['path']
-  SUPPORTERS_API_URL = "#{SUPPORTERS_API_HOST}/#{SUPPORTERS_API_PATH}"
-  #{
 
   # Enable basic auth if the secret is set to true.
   # At EFF we use this to prevent access to our Heroku staging access by setting the enable_basic_auth to 'true' and setting the basic_auth_username and basic_auth_password env variables.

--- a/lib/civicrm.rb
+++ b/lib/civicrm.rb
@@ -9,17 +9,20 @@ module CiviCRM
     end
 
     def subscribe!(opt_in=false, source='action center')
+      return nil if Rails.env == 'test'
       res = CiviCRM::subscribe contact_attributes.merge(opt_in: opt_in, source: source)
       update_attributes(contact_id: res['contact_id']) if (res && res['contact_id'])
     end
 
     def contact_id!
+      return nil if Rails.env == 'test'
       res = CiviCRM::import_contact contact_attributes
       update_attributes(contact_id: res['contact_id']) if (res && res['contact_id'])
       contact_id
     end
 
     def add_civicrm_activity!(action_page_id)
+      return nil if Rails.env == 'test'
       if contact_id && action_page = ActionPage.find_by_id(action_page_id)
         CiviCRM::add_activity(
           contact_id: contact_id,
@@ -30,10 +33,12 @@ module CiviCRM
   end
 
   def self.subscribe(params)
+    return nil if Rails.env == 'test'
     self.import_contact params.merge(subscribe: true)
   end
 
   def self.import_contact(params)
+    return nil if Rails.env == 'test'
     post base_params.merge(
       method: 'import_contact',
       data: {
@@ -53,6 +58,7 @@ module CiviCRM
   end
 
   def self.add_activity(params)
+    return nil if Rails.env == 'test'
     post base_params.merge(
       method: 'add_activity',
       data: params.slice(:contact_id, :subject, :activity_type_id).to_json
@@ -61,8 +67,9 @@ module CiviCRM
 
   private
   def self.post(params)
+    supporters_api_url = "#{Rails.application.secrets.supporters['host']}/#{Rails.application.secrets.supporters['path']}"
     begin
-      res = JSON.parse RestClient.post(SUPPORTERS_API_URL, params)
+      res = JSON.parse RestClient.post(supporters_api_url, params)
       raise res['error_message'] if res['error']
       return res
     rescue => e
@@ -88,6 +95,6 @@ module CiviCRM
   end
 
   def self.base_params
-    { site_key: SUPPORTERS_API_KEY }
+    { site_key: Rails.application.secrets.supporters['api_key'] }
   end
 end


### PR DESCRIPTION
I put all the checks to prevent action during testing into the CiviCRM lib, so the actual rails app calls have a cleaner appearance (and testing definitely won't interfere with a CRM instance).  