### PR TITLE
hiding twitter character count because it was wrong

### DIFF
--- a/app/assets/javascripts/action_page.js
+++ b/app/assets/javascripts/action_page.js
@@ -44,11 +44,15 @@ $('input:radio').screwDefaultButtons({
   height: 15
 });
 
+// Give an approximate character count guide to see how many character's are
+// left in a tweet or social media card.  Tweet length isn't so accurate due to
+// url shorteners and handle names (if they're inserted after the tweet is
+// crafted)
 function addCharacterCount(input) {
   var $input    = $(input),
       maxLength = $input.data('maxlength'),
       remaining = maxLength - $input.val().length;
-  $('<div class="character-counter-text"><span id="' + input.id + '-counter">' + remaining + '</span> characters remaining (max ' + maxLength + ')</div>').insertAfter(input);
+  $('<div class="character-counter-text"><span id="' + input.id + '-counter">&#126; ' + remaining + '</span> characters remaining (max ' + maxLength + ')</div>').insertAfter(input);
 }
 
 $('.charactercount').each(function () {
@@ -58,5 +62,5 @@ $('.charactercount').each(function () {
 $('.charactercount').keyup(function() {
   var $element = $(this),
       maxLength = $element.data('maxlength');
-      $("#" + this.id + "-counter").html(maxLength - $element.val().length);
+      $("#" + this.id + "-counter").html("&#126; " + (maxLength - $element.val().length));
 });

--- a/app/views/admin/action_pages/_panel_social.html.erb
+++ b/app/views/admin/action_pages/_panel_social.html.erb
@@ -7,7 +7,7 @@
           Tweet text
           <span>(URL is automatically added to the end)</span>
         <% end %>
-        <%= f.text_field :share_message, :data => {:maxlength => '116'}, :class  => "charactercount" -%>
+        <%= f.text_field :share_message, :data => {:maxlength => '140'}, :class  => "charactercount" -%>
       </div>
       <div class="form-group">
         <%= f.label :og_title do -%>

--- a/app/views/tools/_tweet.html.erb
+++ b/app/views/tools/_tweet.html.erb
@@ -14,7 +14,7 @@
       </script>
       <% if !@reps.present? && (@tweet.target_house? || @tweet.target_senate?) %>
         <div id='tweet-message-wrapper' style='display: none;'>
-          <textarea class='form-control charactercount' data-maxlength="116" id="tweet-message"><%= @tweet.message.html_safe -%></textarea>
+          <textarea class='form-control' id="tweet-message"><%= @tweet.message.html_safe -%></textarea>
         </div>
         <% if @tweet.targets.count > 0 %>
           <h3 class='twitter-tool-label' style='display: none;'><em>Individuals</em></h3>
@@ -22,7 +22,7 @@
         <% end %>
         <h3 class='twitter-tool-label' style='display: none;'><em>Your Representatives</em></h3>
       <% else %>
-        <textarea class='form-control charactercount' data-maxlength="116" id="tweet-message"><%= @tweet.message.html_safe -%></textarea>
+        <textarea class='form-control' id="tweet-message"><%= @tweet.message.html_safe -%></textarea>
         <% if @tweet.targets.count > 0 %>
           <h3 class='twitter-tool-label'><em>Individuals</em></h3>
           <div id='tweet-tool-container'></div>


### PR DESCRIPTION
This commit is running on production and seems fine.  It's tricky because the admin page uses this function, and so does the user page.  It's non-ideal for on the user page because the 'estimate' of characters left is wrong thus https://redmine.eff.org/issues/8590.  