### PR TITLE
removed reference to call tool configs which was a stub

### DIFF
--- a/app/models/call_tool_config.rb
+++ b/app/models/call_tool_config.rb
@@ -1,2 +1,0 @@
-class CallToolConfig < ActiveRecord::Base
-end

--- a/db/migrate/20151211200545_remove_call_tool_configs.rb
+++ b/db/migrate/20151211200545_remove_call_tool_configs.rb
@@ -1,0 +1,5 @@
+class RemoveCallToolConfigs < ActiveRecord::Migration
+  def change
+    drop_table :call_tool_configs
+  end
+end


### PR DESCRIPTION
Solves #31 I checked the production db, the table is completely empty for sure.  