### PR TITLE
Add action-content id for linking directly to action

### DIFF
--- a/app/views/action_page/show.html.erb
+++ b/app/views/action_page/show.html.erb
@@ -18,7 +18,7 @@
     <use xlink:href="#triangle"></use>
   </svg>
 </div>
-<div class="container action-content" data-action-id="<%= @actionPage.id -%>" >
+<div class="container action-content" id="action-content" data-action-id="<%= @actionPage.id -%>" >
   <div class="row">
     <%= render "tools/container" %>
     <div class="col-sm-7 col-md-6 col-lg-6">


### PR DESCRIPTION
By adding id="action-content" we can link directly to a take action form with some nice padding at the top - this would be useful for the mobile app.

Presumably "action-content" will be a unique id, as "description" is used as an id just below...