### PR TITLE
Build out institutions + affiliations

### DIFF
--- a/app/controllers/admin/institutions_controller.rb
+++ b/app/controllers/admin/institutions_controller.rb
@@ -14,7 +14,7 @@ class Admin::InstitutionsController < Admin::ApplicationController
 
   # POST /admin/action_pages/:action_page_id/institutions
   def create
-    @institution = Institution.new(institution_params)
+    @institution = Institution.find_or_initialize_by(name: institution_params[:name])
     @actionPage.institutions << @institution
 
     respond_to do |format|

--- a/app/models/action_page.rb
+++ b/app/models/action_page.rb
@@ -9,6 +9,7 @@ class ActionPage < ActiveRecord::Base
   has_many :events, class_name: Ahoy::Event
   has_many :action_institutions
   has_many :institutions, through: :action_institutions
+  has_many :affiliations
 
   belongs_to :petition
   belongs_to :tweet

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -1,0 +1,4 @@
+class Affiliation < ActiveRecord::Base
+  belongs_to :action_page
+  has_many :signatures
+end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -2,5 +2,6 @@ class Institution < ActiveRecord::Base
   has_many :action_institutions
   has_many :action_pages, through: :action_institutions
   has_many :signatures
-  validates :name, :presence => true
+  validates_presence_of :name
+  validates_uniqueness_of :name
 end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -1,5 +1,6 @@
 class Institution < ActiveRecord::Base
   has_many :action_institutions
   has_many :action_pages, through: :action_institutions
+  has_many :signatures
   validates :name, :presence => true
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -3,6 +3,8 @@ class Signature < ActiveRecord::Base
   include ApplicationHelper
   belongs_to :user
   belongs_to :petition
+  belongs_to :institution
+  belongs_to :affiliation
 
   before_validation :format_zipcode
   before_save :sanitize_input

--- a/db/migrate/20160616000020_create_affiliations.rb
+++ b/db/migrate/20160616000020_create_affiliations.rb
@@ -1,0 +1,14 @@
+class CreateAffiliations < ActiveRecord::Migration
+  def change
+    create_table :affiliations do |t|
+      t.string :name
+      t.references :action_page, index: true, foreign_key: true
+      t.timestamps null: false
+    end
+
+    change_table :signatures do |t|
+      t.references :institution,  index: true
+      t.references :affiliation, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160610205339) do
+ActiveRecord::Schema.define(version: 20160616000020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,15 @@ ActiveRecord::Schema.define(version: 20160610205339) do
   add_index "action_pages", ["petition_id"], name: "index_action_pages_on_petition_id", using: :btree
   add_index "action_pages", ["slug"], name: "index_action_pages_on_slug", using: :btree
   add_index "action_pages", ["tweet_id"], name: "index_action_pages_on_tweet_id", using: :btree
+
+  create_table "affiliations", force: :cascade do |t|
+    t.string   "name"
+    t.integer  "action_page_id"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
+
+  add_index "affiliations", ["action_page_id"], name: "index_affiliations_on_action_page_id", using: :btree
 
   create_table "ahoy_events", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.uuid     "visit_id"
@@ -207,8 +216,12 @@ ActiveRecord::Schema.define(version: 20160610205339) do
     t.string   "city"
     t.string   "state"
     t.boolean  "anonymous",      default: false
+    t.integer  "institution_id"
+    t.integer  "affiliation_id"
   end
 
+  add_index "signatures", ["affiliation_id"], name: "index_signatures_on_affiliation_id", using: :btree
+  add_index "signatures", ["institution_id"], name: "index_signatures_on_institution_id", using: :btree
   add_index "signatures", ["petition_id"], name: "index_signatures_on_petition_id", using: :btree
   add_index "signatures", ["user_id"], name: "index_signatures_on_user_id", using: :btree
 
@@ -343,4 +356,5 @@ ActiveRecord::Schema.define(version: 20160610205339) do
 
   add_index "visits", ["user_id"], name: "index_visits_on_user_id", using: :btree
 
+  add_foreign_key "affiliations", "action_pages"
 end

--- a/spec/controllers/admin/institutions_controller_spec.rb
+++ b/spec/controllers/admin/institutions_controller_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe Admin::InstitutionsController, type: :controller do
         }.to change(@actionPage.institutions, :count).by(1)
       end
 
+      it "does not create duplicate institutions" do
+        institution = Institution.create! valid_attributes
+        @actionPage.institutions << institution
+        expect {
+          post :create, {:action_page_id => @actionPage.id,
+            :institution => valid_attributes}
+        }.to_not change(Institution, :count)
+      end
+
       it "redirects to the action's institutions overview" do
         post :create, {:action_page_id => @actionPage.id,
           :institution => valid_attributes}

--- a/spec/factories/affiliations.rb
+++ b/spec/factories/affiliations.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :affiliation do
+    name "Student"
+  end
+end

--- a/spec/factories/institutions.rb
+++ b/spec/factories/institutions.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :institution do
-    name "University of California, Berkeley"
+    sequence(:name) { |n| "University of Wherever #{n}" }
   end
 end

--- a/spec/factories/petitions.rb
+++ b/spec/factories/petitions.rb
@@ -40,8 +40,14 @@ FactoryGirl.define do
     enable_affiliations true
 
     after(:create) do |petition|
-      99.times { petition.signatures << FactoryGirl.build(:signature, petition_id: petition.id) }
       10.times { petition.action_page.institutions << FactoryGirl.build(:institution) }
+      5.times { petition.action_page.affiliations << FactoryGirl.build(:affiliation) }
+
+      99.times { petition.signatures << FactoryGirl.build(:signature,
+        petition: petition,
+        institution: petition.action_page.institutions.order("RANDOM()").first,
+        affiliation: petition.action_page.affiliations.order("RANDOM()").first,
+      ) }
     end
   end
 end

--- a/spec/factories/petitions.rb
+++ b/spec/factories/petitions.rb
@@ -43,11 +43,14 @@ FactoryGirl.define do
       10.times { petition.action_page.institutions << FactoryGirl.build(:institution) }
       5.times { petition.action_page.affiliations << FactoryGirl.build(:affiliation) }
 
-      99.times { petition.signatures << FactoryGirl.build(:signature,
-        petition: petition,
-        institution: petition.action_page.institutions.order("RANDOM()").first,
-        affiliation: petition.action_page.affiliations.order("RANDOM()").first,
-      ) }
+      # Assign a variety of institution/affiliation combos to 99 signatures.
+      for i in 0..98
+        petition.signatures << FactoryGirl.build(:signature,
+          petition: petition,
+          institution: petition.action_page.institutions[i%10],
+          affiliation: petition.action_page.affiliations[i%5]
+        )
+      end
     end
   end
 end

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Affiliation, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- Create the affiliation model + add it to action_pages via has_many
- Add institutions and affiliations to signatures
- Prevent duplicate institutions

A petition action with institutions, affiliations, and signatures can now be created with rake petition:create_local.