### PR TITLE
Allow users to sign petition on behalf of institutions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ gem 'will_paginate', '~> 3.0'
 gem 'oauth'
 gem 'email_validator'
 gem 'iso_country_codes'
+gem 'cocoon'                      # Dynamically add and remove nested associations from forms
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
       activesupport (>= 3.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
+    cocoon (1.2.9)
     codeclimate-test-reporter (0.5.0)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.1)
@@ -429,6 +430,7 @@ DEPENDENCIES
   capybara (~> 2.5.0)
   capybara-webkit
   chartkick!
+  cocoon
   codeclimate-test-reporter
   cucumber-rails (= 1.4.2)
   daemons
@@ -500,5 +502,8 @@ DEPENDENCIES
   whenever
   will_paginate (~> 3.0)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -35,3 +35,4 @@
 //= require fuzzyset_util
 //= require bootstrap-formhelpers-phone
 //= require application/social-buttons
+//= require cocoon

--- a/app/assets/javascripts/application/tools/petition.js
+++ b/app/assets/javascripts/application/tools/petition.js
@@ -122,8 +122,10 @@ $(document).on('ready', function() {
   if($('#petition-tool').length != 0) {
     window.setTimeout(getSignatures, getSignaturesInterval);
 
-    $('#signature_zipcode').attr('required', 'required')
-    $('#signature_zipcode').attr('pattern', zip_pattern);
+    if ($('#location.require').length) {
+      $('#signature_zipcode').attr('required', 'required')
+      $('#signature_zipcode').attr('pattern', zip_pattern);
+    }
 
     // Users must input complete institution/relationship pairs.
     $('#affiliations').on('change', 'select', function() {
@@ -138,14 +140,16 @@ $(document).on('ready', function() {
   $('.intl-toggler').click(function(e) {
     $('.intl-toggle').toggle();
     height_changed();
-    if ($('.intl:visible').length) {
-      $('#signature_zipcode').removeAttr('required');
-      $('#signature_zipcode').removeAttr('pattern');
-      $('#signature_city, #signature_country_code').attr('required', 'required');
-    } else {
-      $('#signature_zipcode').attr('required', 'required')
-      $('#signature_zipcode').attr('pattern', zip_pattern);
-      $('#signature_city, #signature_country_code').removeAttr('required');
+    if ($('#location.require').length) {
+      if ($('.intl:visible').length) {
+        $('#signature_zipcode').removeAttr('required');
+        $('#signature_zipcode').removeAttr('pattern');
+        $('#signature_city, #signature_country_code').attr('required', 'required');
+      } else {
+        $('#signature_zipcode').attr('required', 'required')
+        $('#signature_zipcode').attr('pattern', zip_pattern);
+        $('#signature_city, #signature_country_code').removeAttr('required');
+      }
     }
   });
 });

--- a/app/assets/javascripts/application/tools/petition.js
+++ b/app/assets/javascripts/application/tools/petition.js
@@ -123,6 +123,17 @@ $(document).on('ready', function() {
 
     $('#signature_zipcode').attr('required', 'required')
     $('#signature_zipcode').attr('pattern', zip_pattern);
+
+    // Users must input complete institution/relationship pairs.
+    $('#affiliations .nested-fields').each(function(key, el) {
+      var inputs = $(el).find('select');
+      inputs.on('input', function() {
+        at_least_one_selected = _.reduce(inputs, function(m, n) {
+          return m + $(n).val().length;
+        }, 0);
+        inputs.prop('required', at_least_one_selected);
+      });
+    });
   }
 
   $('.intl-toggler').click(function(e) {

--- a/app/assets/javascripts/application/tools/petition.js
+++ b/app/assets/javascripts/application/tools/petition.js
@@ -58,8 +58,9 @@ $(document).on('ready', function() {
           var errors = JSON.parse(data.errors);
           for (var field_name in errors) {
             var field = form.find("#signature_" + field_name);
-            var error = $('<div class="error help-block small">').text(errors[field_name]);
+            var error = errors[field_name];
             if (field.length) {
+              error = $('<div class="error help-block small">').text(error);
               error.prepend(field.attr('placeholder') + ': ');
               field.closest('fieldset').addClass('has-error');
               error.insertAfter(field);

--- a/app/assets/javascripts/application/tools/petition.js
+++ b/app/assets/javascripts/application/tools/petition.js
@@ -126,14 +126,12 @@ $(document).on('ready', function() {
     $('#signature_zipcode').attr('pattern', zip_pattern);
 
     // Users must input complete institution/relationship pairs.
-    $('#affiliations .nested-fields').each(function(key, el) {
-      var inputs = $(el).find('select');
-      inputs.on('input', function() {
-        at_least_one_selected = _.reduce(inputs, function(m, n) {
-          return m + $(n).val().length;
-        }, 0);
-        inputs.prop('required', at_least_one_selected);
-      });
+    $('#affiliations').on('change', 'select', function() {
+      var select_pair = $(this).closest('.nested-fields').find('select');
+      var at_least_one_selected = _.reduce(select_pair, function(m, n) {
+        return m + $(n).val().length;
+      }, 0);
+      select_pair.prop('required', at_least_one_selected);
     });
   }
 

--- a/app/assets/stylesheets/action_page.css.scss
+++ b/app/assets/stylesheets/action_page.css.scss
@@ -117,14 +117,26 @@
     .tool-body {
       padding: 10px;
     }
+    .tool-notice {
+      padding-bottom: 5px;
+    }
     .btn-default[disabled="disabled"] {
       opacity: 0.7;
+    }
+    .add_fields {
+      font-size: 0.8em;
+    }
+    .location-help-text {
+      margin-bottom: 0.2em;
     }
     form {
       text-align: left;
     }
     select {
       max-width: 60%;
+      margin-bottom: 0.5em;
+    }
+    .input-pair {
       margin-bottom: 0.5em;
     }
     .form-group > input[type=text], .form-group > input[type=email], .form-group > input[type=tel]  {
@@ -255,8 +267,8 @@
 
 .intl-toggler {
   cursor: pointer;
-  font-size:14px;
-  margin-top:0.6em;
+  font-size: 0.8em;
+  margin-top: 0.6em;
 }
 
 #tools #tweet-tool {
@@ -412,7 +424,7 @@ h3.header, #tools #email-tool h3 {
 #description .letter, #letter {
   -webkit-box-shadow: 0 0 25px 5px rgba(0,0,0,.1); // iOS <4.3 & Android <4.1
   box-shadow: 0 0 25px 5px rgba(0,0,0,.1);
-  
+
   margin: 2em 0 3em;
   padding: 3em 3em 5em;
   position: relative;

--- a/app/controllers/action_page_controller.rb
+++ b/app/controllers/action_page_controller.rb
@@ -101,9 +101,10 @@ private
       if @petition.show_all_signatures
         @signatures = @petition.signatures.paginate(:page => params[:page], :per_page => 9).order(created_at: :desc)
       else
-        @signatures = @petition.signatures.order(created_at: :desc).limit(5)      
+        @signatures = @petition.signatures.order(created_at: :desc).limit(5)
       end
       @signature_count = @petition.signatures.pretty_count
+      @require_location = !@petition.enable_affiliations
     end
 
     @topic_category = nil

--- a/app/controllers/action_page_controller.rb
+++ b/app/controllers/action_page_controller.rb
@@ -121,6 +121,9 @@ private
                               zipcode: current_zipcode,
                               country_code: current_country_code,
                               email: current_email }
+    if @actionPage.petition and @actionPage.petition.enable_affiliations
+      @signature.affiliations.build
+    end
 
     # Tracking
     if params[:action] == "show"

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -287,7 +287,10 @@ class ToolsController < ApplicationController
   def signature_params
     params.require(:signature).
       permit(:first_name, :last_name, :email, :petition_id, :user_id,
-             :street_address, :city, :state, :country_code, :zipcode, :anonymous)
+             :street_address, :city, :state, :country_code, :zipcode, :anonymous,
+             affiliations_attributes: [:id,
+                                      :institution_id,
+                                      :affiliation_type_id])
   end
 
   def call_params

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -83,9 +83,9 @@ class ToolsController < ApplicationController
     @action_page = Petition.find(params[:signature][:petition_id]).action_page
     @signature = Signature.new(signature_params.merge(user_id: @user.id))
 
-    @signature.country_code = 'US' unless @signature.country_code.present?
+    @signature.country_code = 'US' if @signature.zipcode.present?
 
-    if @signature.country_code == 'US' && @signature.zipcode.present? && @signature.city.blank? && @signature.state.blank? && !Rails.application.secrets.smarty_streets_id.nil?
+    if @signature.country_code == 'US' && !Rails.application.secrets.smarty_streets_id.nil?
       if city_state = SmartyStreets.get_city_state(@signature.zipcode)
         @signature.city = city_state['city']
         @signature.state = city_state['state']

--- a/app/models/action_page.rb
+++ b/app/models/action_page.rb
@@ -9,7 +9,7 @@ class ActionPage < ActiveRecord::Base
   has_many :events, class_name: Ahoy::Event
   has_many :action_institutions
   has_many :institutions, through: :action_institutions
-  has_many :affiliations
+  has_many :affiliation_types
 
   belongs_to :petition
   belongs_to :tweet

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -1,4 +1,6 @@
 class Affiliation < ActiveRecord::Base
   belongs_to :action_page
-  has_many :signatures
+  belongs_to :signature
+  belongs_to :affiliation_type
+  belongs_to :institution
 end

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -3,4 +3,7 @@ class Affiliation < ActiveRecord::Base
   belongs_to :signature
   belongs_to :affiliation_type
   belongs_to :institution
+
+  validates :affiliation_type, presence: true
+  validates :institution, presence: true
 end

--- a/app/models/affiliation_type.rb
+++ b/app/models/affiliation_type.rb
@@ -1,0 +1,4 @@
+class AffiliationType < ActiveRecord::Base
+  belongs_to :action_page
+  has_many :affiliations
+end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -3,7 +3,7 @@ class Institution < ActiveRecord::Base
 
   has_many :action_institutions
   has_many :action_pages, through: :action_institutions
-  has_many :signatures
+  has_many :affiliations
 
   validates_presence_of :name
   validates_uniqueness_of :name

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -3,8 +3,7 @@ class Signature < ActiveRecord::Base
   include ApplicationHelper
   belongs_to :user
   belongs_to :petition
-  belongs_to :institution
-  belongs_to :affiliation
+  has_many :affiliations
 
   before_validation :format_zipcode
   before_save :sanitize_input
@@ -14,6 +13,8 @@ class Signature < ActiveRecord::Base
   validates :email, email: true
   validates :zipcode, length: { maximum: 12 }
   validate :country_code, :arbitrary_opinion_of_country_string_validity
+
+  accepts_nested_attributes_for :affiliations, reject_if: :all_blank
 
   include ActionView::Helpers::DateHelper
 

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -7,8 +7,10 @@ class Signature < ActiveRecord::Base
 
   before_validation :format_zipcode
   before_save :sanitize_input
-  validates_presence_of :first_name, :last_name, :country_code, :petition_id,
+  validates_presence_of :first_name, :last_name, :petition_id,
     message: "This can't be blank."
+
+  validates_presence_of :country_code, :if => :location_required?
 
   validates :email, email: true
   validates :zipcode, length: { maximum: 12 }
@@ -23,7 +25,7 @@ class Signature < ActiveRecord::Base
   end
 
   def arbitrary_opinion_of_country_string_validity
-    if full_country_name.nil?
+    if country_code.present? and full_country_name.nil?
       errors.add(:country_code, "Country Code might come from a spam bot.")
     end
   end
@@ -50,6 +52,10 @@ class Signature < ActiveRecord::Base
 
   def state_symbol
     us_states_hash[state]
+  end
+
+  def location_required?
+    petition.present? && !petition.enable_affiliations
   end
 
   def full_country_name

--- a/app/views/affiliations/_affiliation_fields.html.erb
+++ b/app/views/affiliations/_affiliation_fields.html.erb
@@ -2,8 +2,6 @@
   <fieldset class='form-group'>
     <%= f.label :institution_id, class: 'sr-only'-%>
     <%= f.collection_select :institution_id, @actionPage.institutions, :id, :name, { prompt: t(:institution) }, { class: 'form-control' } -%>
-  </fieldset>
-  <fieldset>
     <%= f.label :affiliation_type_id, class: 'sr-only'-%>
     <%= f.collection_select :affiliation_type_id, @actionPage.affiliation_types, :id, :name, { prompt: t(:i_am_a) }, { class: 'form-control' } -%>
   </fieldset>

--- a/app/views/affiliations/_affiliation_fields.html.erb
+++ b/app/views/affiliations/_affiliation_fields.html.erb
@@ -1,8 +1,15 @@
 <div class='nested-fields'>
   <fieldset class='form-group'>
     <%= f.label :institution_id, class: 'sr-only'-%>
-    <%= f.collection_select :institution_id, @actionPage.institutions, :id, :name, { prompt: t(:institution) }, { class: 'form-control' } -%>
+    <%= f.collection_select :institution_id, @actionPage.institutions, :id, :name,
+      { prompt: t(:institution) },
+      { class: 'form-control', title: t('petition_errors.required.institution') }
+    -%>
+
     <%= f.label :affiliation_type_id, class: 'sr-only'-%>
-    <%= f.collection_select :affiliation_type_id, @actionPage.affiliation_types, :id, :name, { prompt: t(:i_am_a) }, { class: 'form-control' } -%>
+    <%= f.collection_select :affiliation_type_id, @actionPage.affiliation_types, :id, :name,
+      { prompt: t(:i_am_a) },
+      { class: 'form-control', title: t('petition_errors.required.affiliation_type') }
+    -%>
   </fieldset>
 </div>

--- a/app/views/affiliations/_affiliation_fields.html.erb
+++ b/app/views/affiliations/_affiliation_fields.html.erb
@@ -1,0 +1,10 @@
+<div class='nested-fields'>
+  <fieldset class='form-group'>
+    <%= f.label :institution_id, class: 'sr-only'-%>
+    <%= f.collection_select :institution_id, @actionPage.institutions, :id, :name, { prompt: t(:institution) }, { class: 'form-control' } -%>
+  </fieldset>
+  <fieldset>
+    <%= f.label :affiliation_type_id, class: 'sr-only'-%>
+    <%= f.collection_select :affiliation_type_id, @actionPage.affiliation_types, :id, :name, { prompt: t(:i_am_a) }, { class: 'form-control' } -%>
+  </fieldset>
+</div>

--- a/app/views/tools/_petition.html.erb
+++ b/app/views/tools/_petition.html.erb
@@ -87,6 +87,14 @@
                 class: 'form-control', pattern: '.*\S+.*', title: t('petition_errors.required.last_name')
               -%>
             </fieldset>
+            <div id='affiliations'>
+              <%= f.fields_for :affiliations, Affiliation.new do |affiliation| %>
+                <%= render 'affiliations/affiliation_fields', :f => affiliation %>
+              <% end %>
+              <div class='links'>
+                <%= link_to_add_association 'Add another', f, :affiliations, partial: 'affiliations/affiliation_fields' %>
+              </div>
+            </div>
             <fieldset>
               <span class='intl-toggle'>
                 <div class="row">

--- a/app/views/tools/_petition.html.erb
+++ b/app/views/tools/_petition.html.erb
@@ -87,39 +87,44 @@
                 class: 'form-control', pattern: '.*\S+.*', title: t('petition_errors.required.last_name')
               -%>
             </fieldset>
-            <div id='affiliations'>
-              <%= f.fields_for :affiliations, Affiliation.new do |affiliation| %>
-                <%= render 'affiliations/affiliation_fields', :f => affiliation %>
-              <% end %>
-              <div class='links'>
-                <%= link_to_add_association 'Add another', f, :affiliations, partial: 'affiliations/affiliation_fields' %>
+
+            <% if @actionPage.petition.enable_affiliations %>
+              <div id='affiliations'>
+                <%= f.fields_for :affiliations, Affiliation.new do |affiliation| %>
+                  <%= render 'affiliations/affiliation_fields', :f => affiliation %>
+                <% end %>
+                <div class='links'>
+                  <%= link_to_add_association 'Add another', f, :affiliations, partial: 'affiliations/affiliation_fields' %>
+                </div>
               </div>
-            </div>
-            <fieldset>
-              <span class='intl-toggle'>
-                <div class="row">
-                  <div class="col-xs-6">
-                    <%= f.text_field :zipcode, class: 'form-control', placeholder: t(:zip_code),
-                      title: t('petition_errors.required.zip_code') -%>
-                    </div>
+            <% else %>
+              <fieldset>
+                <span class='intl-toggle'>
+                  <div class="row">
                     <div class="col-xs-6">
-                      <a class='intl-toggler pull-right hidden-if-no-js'><%= t :outside_the_us -%></a>
+                      <%= f.text_field :zipcode, class: 'form-control', placeholder: t(:zip_code),
+                        title: t('petition_errors.required.zip_code') -%>
+                      </div>
+                      <div class="col-xs-6">
+                        <a class='intl-toggler pull-right hidden-if-no-js'><%= t :outside_the_us -%></a>
+                      </div>
                     </div>
-                  </div>
-              </span>
-            </fieldset>
-            <div class='intl-toggle intl collapse'>
-              <fieldset>
-                <%= f.text_field :city, placeholder: t(:city),
-                  class: 'form-control', pattern: '.*\S+.*', title: t('petition_errors.required.city')
-                -%>
+                </span>
               </fieldset>
-              <fieldset>
-                <a class='intl-toggler pull-right hidden-if-no-js'><%= t :in_the_us -%></a>
-                <%= f.select :country_code, country_codes, { prompt: t(:country) },
-                  class: 'form-control' -%>
-              </fieldset>
-            </div>
+              <div class='intl-toggle intl collapse'>
+                <fieldset>
+                  <%= f.text_field :city, placeholder: t(:city),
+                    class: 'form-control', pattern: '.*\S+.*', title: t('petition_errors.required.city')
+                  -%>
+                </fieldset>
+                <fieldset>
+                  <a class='intl-toggler pull-right hidden-if-no-js'><%= t :in_the_us -%></a>
+                  <%= f.select :country_code, country_codes, { prompt: t(:country) },
+                    class: 'form-control' -%>
+                </fieldset>
+              </div>
+            <% end %>
+
             <fieldset>
               <%= render 'tools/save_my_info_option', info: t(%w[email name location]) -%>
               <div class='checkbox small'>

--- a/app/views/tools/_petition.html.erb
+++ b/app/views/tools/_petition.html.erb
@@ -27,7 +27,7 @@
     <div class="tool-body">
       <%- if @petition.enable_affiliations -%>
         <div class='small tool-notice'>
-          Your name and affiliations will be published on our site.
+          <%= t :name_and_affiliations_published -%>
         </div>
       <% end %>
 
@@ -102,7 +102,7 @@
                   <%= render 'affiliations/affiliation_fields', :f => affiliation %>
                 <% end %>
                 <div class='links text-right'>
-                  <%= link_to_add_association '+ Add another institution', f, :affiliations, partial: 'affiliations/affiliation_fields' %>
+                  <%= link_to_add_association t(:add_another_institution), f, :affiliations, partial: 'affiliations/affiliation_fields' %>
                 </div>
               </div>
             <% end %>

--- a/app/views/tools/_petition.html.erb
+++ b/app/views/tools/_petition.html.erb
@@ -14,6 +14,7 @@
 </script>
 <div id='petition-tool' class="tool <%= 'un' unless current_user.try(:signed?, @actionPage.petition) || params[:thankyou] -%>signed">
   <div class="tool-container">
+
     <div class="tool-heading">
       <h2 class="tool-title signed">
         <span class='glyphicon glyphicon-ok'></span>Signed
@@ -22,7 +23,14 @@
         <%= t :sign_the_petition -%>
       </h2>
     </div>
+
     <div class="tool-body">
+      <%- if @petition.enable_affiliations -%>
+        <div class='small tool-notice'>
+          Your name and affiliations will be published on our site.
+        </div>
+      <% end %>
+
       <%- if @actionPage.petition.goal -%>
         <div id="progress-bar">
           <div class='count'><b><%= @signature_count -%></b> /
@@ -38,8 +46,8 @@
           <div class='count'><b><%= @signature_count -%></b><span class='goal'> <%= t :signatures -%></span>
           </div>
         </div>
-
       <% end -%>
+
         <div class='signed'>
           <div class='vertical-share'>
             <b class='small'>Now help spread the word:</b>
@@ -93,46 +101,26 @@
                 <%= f.fields_for :affiliations, Affiliation.new do |affiliation| %>
                   <%= render 'affiliations/affiliation_fields', :f => affiliation %>
                 <% end %>
-                <div class='links'>
-                  <%= link_to_add_association 'Add another', f, :affiliations, partial: 'affiliations/affiliation_fields' %>
+                <div class='links text-right'>
+                  <%= link_to_add_association '+ Add another institution', f, :affiliations, partial: 'affiliations/affiliation_fields' %>
                 </div>
-              </div>
-            <% else %>
-              <fieldset>
-                <span class='intl-toggle'>
-                  <div class="row">
-                    <div class="col-xs-6">
-                      <%= f.text_field :zipcode, class: 'form-control', placeholder: t(:zip_code),
-                        title: t('petition_errors.required.zip_code') -%>
-                      </div>
-                      <div class="col-xs-6">
-                        <a class='intl-toggler pull-right hidden-if-no-js'><%= t :outside_the_us -%></a>
-                      </div>
-                    </div>
-                </span>
-              </fieldset>
-              <div class='intl-toggle intl collapse'>
-                <fieldset>
-                  <%= f.text_field :city, placeholder: t(:city),
-                    class: 'form-control', pattern: '.*\S+.*', title: t('petition_errors.required.city')
-                  -%>
-                </fieldset>
-                <fieldset>
-                  <a class='intl-toggler pull-right hidden-if-no-js'><%= t :in_the_us -%></a>
-                  <%= f.select :country_code, country_codes, { prompt: t(:country) },
-                    class: 'form-control' -%>
-                </fieldset>
               </div>
             <% end %>
 
+            <% if @require_location %>
+              <%= render 'tools/petition_location', f: f %>
+            <% end %>
+
             <fieldset>
-              <%= render 'tools/save_my_info_option', info: t(%w[email name location]) -%>
-              <div class='checkbox small'>
-                <%= f.label :anonymous, class: :small do -%>
-                  <%= check_box_tag 'signature[anonymous]' -%>
-                  <%= t :dont_show_my_name -%>
-                <% end -%>
-              </div>
+              <% unless @petition.enable_affiliations %>
+                <div class='checkbox small'>
+                  <%= f.label :anonymous, class: :small do -%>
+                    <%= check_box_tag 'signature[anonymous]' -%>
+                    <%= t :dont_show_my_name -%>
+                  <% end -%>
+                </div>
+              <% end %>
+
               <%- unless user_signed_in? -%>
                 <div class="email-signup">
                   <%= t :i -%>
@@ -144,6 +132,11 @@
                   <%= t :to_sign_up_for_mailings_from -%> <b><%= t :organization_abbreviation -%></b>
                 </div>
               <% end -%>
+
+              <% unless @require_location %>
+                <%= render 'tools/petition_location', f: f %>
+              <% end %>
+
               <% if @actionPage.partner -%>
                 <div class="email-signup">
                   <%= t :i -%>
@@ -155,6 +148,9 @@
                   (<%= link_to 'privacy policy', @actionPage.partner.privacy_url -%>).
                 </div>
               <% end -%>
+
+              <%= render 'tools/save_my_info_option', info: t(%w[email name location]) -%>
+
             </fieldset>
             <% button_text = params.include?("button_text") ? params["button_text"].to_sym : t(:speak_out) %>
             <%= f.submit button_text, class: 'btn'-%>
@@ -164,6 +160,7 @@
     </div>
   </div>
 </div>
+
 <% if !@petition.show_all_signatures -%>
 <div id='signatures' class="hidden-xs">
   <h4 class='header'><em><%= t :recent_signatories -%></em></h4>

--- a/app/views/tools/_petition_location.html.erb
+++ b/app/views/tools/_petition_location.html.erb
@@ -1,4 +1,4 @@
-<fieldset>
+<fieldset id='location' <%= 'class=require' if @require_location -%>>
   <% unless @require_location %>
     <div class='small location-help-text'>
       <%= t :get_involved_local %>

--- a/app/views/tools/_petition_location.html.erb
+++ b/app/views/tools/_petition_location.html.erb
@@ -1,0 +1,26 @@
+<fieldset>
+  <% unless @require_location %>
+    <div class='small location-help-text'>Get involved with EFF in your area</div>
+  <% end %>
+
+  <span class='intl-toggle'>
+    <div class="row">
+      <div class="col-xs-6">
+        <%= f.text_field :zipcode, class: 'form-control', placeholder: t(:zip_code),
+          title: t('petition_errors.required.zip_code') -%>
+      </div>
+      <div class="col-xs-6">
+          <a class='intl-toggler pull-right hidden-if-no-js'><%= t :outside_the_us -%></a>
+      </div>
+    </div>
+  </span>
+
+  <div class='intl-toggle intl collapse'>
+      <%= f.text_field :city, placeholder: t(:city),
+        class: 'form-control input-pair', pattern: '.*\S+.*', title: t('petition_errors.required.city')
+      -%>
+      <a class='intl-toggler pull-right hidden-if-no-js'><%= t :in_the_us -%></a>
+      <%= f.select :country_code, country_codes, { prompt: t(:country) },
+        class: 'form-control' -%>
+  </div>
+</fieldset>

--- a/app/views/tools/_petition_location.html.erb
+++ b/app/views/tools/_petition_location.html.erb
@@ -1,6 +1,8 @@
 <fieldset>
   <% unless @require_location %>
-    <div class='small location-help-text'>Get involved with EFF in your area</div>
+    <div class='small location-help-text'>
+      <%= t :get_involved_local %>
+    </div>
   <% end %>
 
   <span class='intl-toggle'>

--- a/app/views/tools/_signatures.html.erb
+++ b/app/views/tools/_signatures.html.erb
@@ -8,7 +8,7 @@
         <% if @actionPage.petition.enable_affiliations %>
           <% signature.affiliations.each do |affiliation| %>
             <div>
-              <%= affiliation.institution.name %>, <%= affiliation.affiliation_type.name %>
+              <%= affiliation.institution.name -%>, <%= affiliation.affiliation_type.name -%>
             </div>
           <% end %>
         <% end %>

--- a/app/views/tools/_signatures.html.erb
+++ b/app/views/tools/_signatures.html.erb
@@ -4,13 +4,14 @@
     <tr>
       <td>
         <div><%= signature.anonymous ? 'Anonymous' : signature.name -%></div>
-        <div><%= signature.anonymous ? signature.country_code : signature.location %></div>
         <% if @actionPage.petition.enable_affiliations %>
           <% signature.affiliations.each do |affiliation| %>
             <div>
               <%= affiliation.institution.name -%>, <%= affiliation.affiliation_type.name -%>
             </div>
           <% end %>
+        <% else %>
+          <div><%= signature.anonymous ? signature.country_code : signature.location %></div>
         <% end %>
       </td>
 

--- a/app/views/tools/_signatures.html.erb
+++ b/app/views/tools/_signatures.html.erb
@@ -5,6 +5,13 @@
       <td>
         <div><%= signature.anonymous ? 'Anonymous' : signature.name -%></div>
         <div><%= signature.anonymous ? signature.country_code : signature.location %></div>
+        <% if @actionPage.petition.enable_affiliations %>
+          <% signature.affiliations.each do |affiliation| %>
+            <div>
+              <%= affiliation.institution.name %>, <%= affiliation.affiliation_type.name %>
+            </div>
+          <% end %>
+        <% end %>
       </td>
 
       <td class="timeago" title="<%= signature.created_at.to_time.iso8601 %>">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,9 @@ en:
   zip_code: Zip Code
   city: City
   country: Country
+  add_another_institution: + Add another institution
+  name_and_affiliations_published: Your name and affiliations will be published on our site.
+  get_involved_local: Get involved with EFF in your area
   petition_errors:
     required:
       email: Enter a valid email
@@ -67,3 +70,5 @@ en:
       last_name: Enter your last name
       zip_code: Enter your 5 or 9 digit zip code
       city: Enter your city
+      institution: Select an institution
+      affiliation_type: How are you affilliated with this institution?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,8 @@ en:
   signatures: signatures
   first_name: First Name
   last_name: Last Name
+  institution: Institution
+  i_am_a: I am a...
   zip_code: Zip Code
   city: City
   country: Country

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -48,7 +48,7 @@ es:
   in_the_us: ¿Está en los EE.UU.?
   speak_out: Pronúnciate
   recent_signatories: Últimos Firmantes
-  recent_signatories: Todos Firmantes
+  all_signatures: Todos Firmantes
   signed: Firmado
   your_name: Su Nombre
   sign_the_petition: Firme la petición
@@ -56,6 +56,9 @@ es:
   first_name: Nombre
   last_name: Apellido
   institution: Institución
+  add_another_institution: + Add another institution
+  name_and_affiliations_published: Your name and affiliations will be published on our site.
+  get_involved_local: Get involved with EFF in your area
   i_am_a: Soy un...
   zip_code: Codigo Postal
   city: Ciudad
@@ -68,6 +71,8 @@ es:
       last_name: Introduzca su apellido
       zip_code: Introduzca su código postal de 5 o 9 dígitos
       city: Introduzca su ciudad
+      institution: Select an institution
+      affiliation_type: How are you affilliated with this institution?
   date:
     abbr_day_names:
     - dom

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -55,6 +55,8 @@ es:
   signatures: firmas
   first_name: Nombre
   last_name: Apellido
+  institution: Institución
+  i_am_a: Soy un...
   zip_code: Codigo Postal
   city: Ciudad
   country: Pais

--- a/db/migrate/20160629191322_create_affiliation_types.rb
+++ b/db/migrate/20160629191322_create_affiliation_types.rb
@@ -1,0 +1,20 @@
+class CreateAffiliationTypes < ActiveRecord::Migration
+  def change
+    create_table :affiliation_types do |t|
+      t.string :name
+      t.references :action_page, index: true
+      t.timestamps null: false
+    end
+
+    remove_column :affiliations, :action_page_id, :integer, index: true
+    remove_column :affiliations, :name, :string
+    change_table :affiliations do |t|
+      t.references :signature,  index: true
+      t.references :institution,  index: true
+      t.references :affiliation_type, index: true
+    end
+
+    remove_column :signatures, :institution_id, :integer, index: true
+    remove_column :signatures, :affiliation_id, :integer, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160616000020) do
+ActiveRecord::Schema.define(version: 20160629191322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,14 +78,26 @@ ActiveRecord::Schema.define(version: 20160616000020) do
   add_index "action_pages", ["slug"], name: "index_action_pages_on_slug", using: :btree
   add_index "action_pages", ["tweet_id"], name: "index_action_pages_on_tweet_id", using: :btree
 
-  create_table "affiliations", force: :cascade do |t|
+  create_table "affiliation_types", force: :cascade do |t|
     t.string   "name"
     t.integer  "action_page_id"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
   end
 
-  add_index "affiliations", ["action_page_id"], name: "index_affiliations_on_action_page_id", using: :btree
+  add_index "affiliation_types", ["action_page_id"], name: "index_affiliation_types_on_action_page_id", using: :btree
+
+  create_table "affiliations", force: :cascade do |t|
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.integer  "signature_id"
+    t.integer  "institution_id"
+    t.integer  "affiliation_type_id"
+  end
+
+  add_index "affiliations", ["affiliation_type_id"], name: "index_affiliations_on_affiliation_type_id", using: :btree
+  add_index "affiliations", ["institution_id"], name: "index_affiliations_on_institution_id", using: :btree
+  add_index "affiliations", ["signature_id"], name: "index_affiliations_on_signature_id", using: :btree
 
   create_table "ahoy_events", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.uuid     "visit_id"
@@ -216,12 +228,8 @@ ActiveRecord::Schema.define(version: 20160616000020) do
     t.string   "city"
     t.string   "state"
     t.boolean  "anonymous",      default: false
-    t.integer  "institution_id"
-    t.integer  "affiliation_id"
   end
 
-  add_index "signatures", ["affiliation_id"], name: "index_signatures_on_affiliation_id", using: :btree
-  add_index "signatures", ["institution_id"], name: "index_signatures_on_institution_id", using: :btree
   add_index "signatures", ["petition_id"], name: "index_signatures_on_petition_id", using: :btree
   add_index "signatures", ["user_id"], name: "index_signatures_on_user_id", using: :btree
 
@@ -356,5 +364,4 @@ ActiveRecord::Schema.define(version: 20160616000020) do
 
   add_index "visits", ["user_id"], name: "index_visits_on_user_id", using: :btree
 
-  add_foreign_key "affiliations", "action_pages"
 end

--- a/features/action_page/affiliation.feature
+++ b/features/action_page/affiliation.feature
@@ -12,12 +12,15 @@ Feature: Users petition an institution
     And I click "Add another"
     And I select "University of Wherever 2" from "Institution" within ".nested-fields:nth-child(2)"
     And I select "Parent" from "Affiliation type" within ".nested-fields:nth-child(2)"
-    And I complete the petition
+    And I fill in my name
+    And I fill in my email
+    And I submit the petition
     And I reload the page
     Then I should see "Student" within "#signatures"
     And I should see "University Of Wherever 1" within "#signatures"
     And I should see "Parent" within "#signatures"
     And I should see "University Of Wherever 2" within "#signatures"
+    And I should not see "US" within "#signatures"
 
   Scenario: Users must input complete affiliation/relationship pairs
     When I browse to the action page

--- a/features/action_page/affiliation.feature
+++ b/features/action_page/affiliation.feature
@@ -1,0 +1,20 @@
+@javascript
+Feature: Users petition an institution
+
+  Background:
+    Given a local organizing campaign
+    And the local organizing campaign has multiple institutions
+
+  Scenario: Users should be able to sign a local organizing petition on behalf of their school
+    When I browse to the action page
+    And I select "University of Wherever 1" from "Institution"
+    And I select "Student" from "Affiliation type"
+    And I click "Add another"
+    And I select "University of Wherever 2" from "Institution" within ".nested-fields:nth-child(2)"
+    And I select "Parent" from "Affiliation type" within ".nested-fields:nth-child(2)"
+    And I complete the petition
+    And I reload the page
+    Then I should see "Student" within "#signatures"
+    And I should see "University Of Wherever 1" within "#signatures"
+    And I should see "Parent" within "#signatures"
+    And I should see "University Of Wherever 2" within "#signatures"

--- a/features/action_page/affiliation.feature
+++ b/features/action_page/affiliation.feature
@@ -18,3 +18,14 @@ Feature: Users petition an institution
     And I should see "University Of Wherever 1" within "#signatures"
     And I should see "Parent" within "#signatures"
     And I should see "University Of Wherever 2" within "#signatures"
+
+  Scenario: Users must input complete affiliation/relationship pairs
+    When I browse to the action page
+    And I select "Student" from "Affiliation type"
+    And I click "Add another"
+    And I select "University of Wherever 2" from "Institution" within ".nested-fields:nth-child(2)"
+    And I click "Add another"
+    Then "Institution" should be required within ".nested-fields:nth-child(1)"
+    And "Affiliation type" should be required within ".nested-fields:nth-child(2)"
+    And "Institution" should not be required within ".nested-fields:nth-child(3)"
+    And "Affiliation type" should not be required within ".nested-fields:nth-child(3)"

--- a/features/step_definitions/action_page_steps.rb
+++ b/features/step_definitions/action_page_steps.rb
@@ -45,19 +45,18 @@ Then(/^I should receive a CSV file$/) do
   page.response_headers['Content-Disposition'].should == "attachment"
 end
 
-When(/^I complete the petition$/) do
+When(/^I fill in my name$/) do
   create_visitor
   fill_in "First Name", with: @visitor[:name].split(" ").first
   fill_in "Last Name", with: @visitor[:name].split(" ").last
-  fill_in "Email", :with => @visitor[:email]
-  fill_in "Zip Code", with: "94109"
+end
 
-  RSpec::Mocks.with_temporary_scope do
-    stub_smarty_streets
-    SmartyStreets.get_city_state("94109")
-    click_button "Speak Out"
-    # It's important to wait the request to complete before
-    # leaving the `with_temporary_scope` block or the stub will disappear
-    sleep 0.5 while !page.has_content? "Now help spread the word:"
-  end
+When(/^I fill in my email$/) do
+  create_visitor
+  fill_in "Email", :with => @visitor[:email]
+end
+
+When(/^I submit the petition$/) do
+  click_button "Speak Out"
+  sleep 0.5 while !page.has_content? "Now help spread the word:"
 end

--- a/features/step_definitions/action_page_steps.rb
+++ b/features/step_definitions/action_page_steps.rb
@@ -12,6 +12,17 @@ Given(/^local affiliations are allowed$/) do
   @action_page.save
 end
 
+Given(/^a local organizing campaign/) do
+  @action_page = FactoryGirl.create(:local_organizing_petition).action_page
+end
+
+Given(/^the local organizing campaign has multiple institutions$/) do
+  @action_page.institutions << Institution.create(name: "University of Wherever 2")
+  @action_page.affiliation_types << AffiliationType.create(name: "Parent")
+  @action_page.save
+end
+
+
 When(/^I visit an action page$/) do
   # visit action_page_path(@action_page)
   visit "/action/#{@action_page.title.downcase.gsub(" ", "-")}"
@@ -21,8 +32,32 @@ When(/^I edit the action page$/) do
   visit edit_admin_action_page_path(@action_page)
 end
 
+When(/^I input a second affiliation$/) do
+  within('#affiliations .nested-fields:nth-child(2)') {
+    select("University of Wherever 2", :from => "Institution")
+    select("Parent", :from => "Affiliation type")
+  }
+end
+
 Then(/^I should receive a CSV file$/) do
   current_path.should == "/petition/#{@action_page.petition.id}/signatures.csv"
   page.response_headers['Content-Type'].should == "application/octet-stream"
   page.response_headers['Content-Disposition'].should == "attachment"
+end
+
+When(/^I complete the petition$/) do
+  create_visitor
+  fill_in "First Name", with: @visitor[:name].split(" ").first
+  fill_in "Last Name", with: @visitor[:name].split(" ").last
+  fill_in "Email", :with => @visitor[:email]
+  fill_in "Zip Code", with: "94109"
+
+  RSpec::Mocks.with_temporary_scope do
+    stub_smarty_streets
+    SmartyStreets.get_city_state("94109")
+    click_button "Speak Out"
+    # It's important to wait the request to complete before
+    # leaving the `with_temporary_scope` block or the stub will disappear
+    sleep 0.5 while !page.has_content? "Now help spread the word:"
+  end
 end

--- a/features/step_definitions/action_page_steps.rb
+++ b/features/step_definitions/action_page_steps.rb
@@ -17,7 +17,7 @@ Given(/^a local organizing campaign/) do
 end
 
 Given(/^the local organizing campaign has multiple institutions$/) do
-  @action_page.institutions << Institution.create(name: "University of Wherever 2")
+  @action_page.institutions.find_or_create_by(name: "University of Wherever 2")
   @action_page.affiliation_types << AffiliationType.create(name: "Parent")
   @action_page.save
 end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -120,6 +120,10 @@ Then(/^I should see "(.*?)" within "(.*?)"$/) do |text, container|
   find(container).should have_content(text)
 end
 
+Then(/^I should not see "(.*?)" within "(.*?)"$/) do |text, container|
+  find(container).should_not have_content(text)
+end
+
 When(/^I save the page$/) do
   # Saves HTML to tmp/capybara. Useful for debugging.
   save_page

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -124,3 +124,15 @@ When(/^I save the page$/) do
   # Saves HTML to tmp/capybara. Useful for debugging.
   save_page
 end
+
+Then(/^"(.*?)" should be required within "(.*?)"$/) do |name, container|
+  within(container) {
+    find_field(name)['required'].should == ""
+  }
+end
+
+Then(/^"(.*?)" should not be required within "(.*?)"$/) do |name, container|
+  within(container) {
+    find_field(name)['required'].should == nil
+  }
+end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -36,6 +36,12 @@ When /^I select "([^\"]*)" from "([^\"]*)"$/ do |value, field|
   select(value, :from => field)
 end
 
+When /^I select "([^\"]*)" from "([^\"]*)" within "([^\"]*)"$/ do |value, field, container|
+  within(container) {
+    select(value, :from => field)
+  }
+end
+
 When /^I check "([^\"]*)"$/ do |field|
   check(field)
 end
@@ -102,6 +108,19 @@ When(/^I switch to the new window$/) do
   page.driver.browser.window_focus page.windows.last.handle
 end
 
+When(/^I reload the page$/) do
+  visit current_path
+end
+
 When(/^I attach the file "(.*?)" to "(.*?)"$/) do |path, element|
   attach_file(element, path)
+end
+
+Then(/^I should see "(.*?)" within "(.*?)"$/) do |text, container|
+  find(container).should have_content(text)
+end
+
+When(/^I save the page$/) do
+  # Saves HTML to tmp/capybara. Useful for debugging.
+  save_page
 end

--- a/lib/tasks/petition.rake
+++ b/lib/tasks/petition.rake
@@ -25,10 +25,10 @@ namespace :petition do
     for i in 0..98
       petition.signatures << FactoryGirl.build(:signature,
         petition: petition,
-        affiliation: FactoryGirl.build(:affiliation,
-          institution: petition.action_page.institutions[i%10],
-          affiliation_type: petition.action_page.affiliation_types[i%5]
-        )
+      )
+      petition.signatures.last.affiliations << FactoryGirl.build(:affiliation,
+        institution: petition.action_page.institutions[i%10],
+        affiliation_type: petition.action_page.affiliation_types[i%5]
       )
     end
   end

--- a/lib/tasks/petition.rake
+++ b/lib/tasks/petition.rake
@@ -18,10 +18,19 @@ def next_goal(goal)
 end
 
 namespace :petition do
-
-  desc "Create a local organizing petition"
+  desc "Create a local organizing petition with 99 signatures"
   task :create_local => :environment do
-    @petition = FactoryGirl.create(:local_organizing_petition)
+    petition = FactoryGirl.create(:local_organizing_petition)
+
+    for i in 0..98
+      petition.signatures << FactoryGirl.build(:signature,
+        petition: petition,
+        affiliation: FactoryGirl.build(:affiliation,
+          institution: petition.action_page.institutions[i%10],
+          affiliation_type: petition.action_page.affiliation_types[i%5]
+        )
+      )
+    end
   end
 
   desc "Update moving target petition goals"

--- a/spec/factories/affiliation_types.rb
+++ b/spec/factories/affiliation_types.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :affiliation_type do
+    name "Student"
+  end
+end

--- a/spec/factories/affiliations.rb
+++ b/spec/factories/affiliations.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :affiliation do
-    name "Student"
+    institution
+    affiliation_type
   end
 end

--- a/spec/factories/petitions.rb
+++ b/spec/factories/petitions.rb
@@ -40,17 +40,8 @@ FactoryGirl.define do
     enable_affiliations true
 
     after(:create) do |petition|
-      10.times { petition.action_page.institutions << FactoryGirl.build(:institution) }
-      5.times { petition.action_page.affiliations << FactoryGirl.build(:affiliation) }
-
-      # Assign a variety of institution/affiliation combos to 99 signatures.
-      for i in 0..98
-        petition.signatures << FactoryGirl.build(:signature,
-          petition: petition,
-          institution: petition.action_page.institutions[i%10],
-          affiliation: petition.action_page.affiliations[i%5]
-        )
-      end
+      petition.action_page.institutions << FactoryGirl.build(:institution)
+      petition.action_page.affiliation_types << FactoryGirl.build(:affiliation_type)
     end
   end
 end

--- a/spec/models/affiliation_type_spec.rb
+++ b/spec/models/affiliation_type_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AffiliationType, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
-Create affiliation model that holds institution and affiliation_type
-Add affiliations to the petition form, using cocoon gem for "Add another"
-Show affiliations with signatures

Not included in this PR:
-Autocomplete select menu 
-Didn't style content (waiting until more changes to form are done)
-Location info should not be required or displayed on local organizing petitions