### PR TITLE
Only regenerate friendly id if title changed

### DIFF
--- a/app/models/action_page.rb
+++ b/app/models/action_page.rb
@@ -29,7 +29,9 @@ class ActionPage < ActiveRecord::Base
   #validates_length_of :og_title, maximum: 65
   after_save :no_drafts_on_homepage
 
-  def should_generate_new_friendly_id?; true; end # related to friendly_id
+  def should_generate_new_friendly_id?
+    title_changed?
+  end
 
   def call_tool_title
     call_campaign && call_campaign.title.length > 0 && call_campaign.title || 'Call Your Legislators'


### PR DESCRIPTION
I want to create a custom slug for Elliot using the rails console. Under the current setup, it will be overwritten on save.