### PR TITLE
Improve setup workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Follow these instructions to run the Action Center using Docker (recommended). T
 1. Install Docker ([instructions](https://docs.docker.com/engine/installation/)) and Docker Compose ([instructions](https://docs.docker.com/compose/install/)).
 2. `git clone https://github.com/EFForg/action-center-platform.git`
 3. Copy `docker-compose.example.yml` to `docker-compose.yml`. Fill it in according to the instructions in that file. See [notable dependencies](#notable-dependencies) for hints.
-4. From within the project directory, run `sudo docker-compose up --build`.
-5. In a new tab, get a bash shell with access to your app: `sudo docker-compose exec app bash`.
+4. Build the docker image: `sudo docker-compose build`
+5. Run the application: `sudo docker-compose up`
+6. In a new tab, get a bash shell with access to your app: `sudo docker-compose exec app bash`.
     1. If you aren't running migrations automatically, run `rake db:migrate` to migrate the database.
 
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,24 @@ Action Center administrators can create four types of actions:
 
 To get started using the Action Center, create a user and grant them admin privileges. Administrators can create, track, and manage campaigns.
 
-To create an admin user: First, create a user through the web interface by following the `register` link in the top nav. Then:
-`rake users:add_admin[youremail@example.org]`
+**To create an admin user**:
+
+1. If the user doesn't exist yet, create them through the web interface by following the `register` link in the top nav.
+2. Run the rake task to grant them admin access (including square brackets):
+```
+rake users:add_admin[youremail@example.org]
+```
 New users will need to complete an e-mail confirmation in order to log in. Administrators can access admin features by clicking `admin` in the nav.
 
-To remove an admin:
-`rake users:remove_admin[youremail@example.org]`
+**To remove an admin user**:
+```
+rake users:remove_admin[youremail@example.org]
+```
 
-To list all admin users:
-`rake users:list_admins `
+**To list all admin users**:
+```
+rake users:list_admins
+```
 
 
 ### Embedding Actions

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -19,7 +19,6 @@ services:
 
   app:
     build: .
-    restart: always
 
     # # Expose ports for development.
     # ports:
@@ -30,6 +29,8 @@ services:
 
     # # Serve Rails using unicorn in production.
     # command: bash -c unicorn
+    # # Automatically restart the app on exit in production.
+    # restart: always
 
     environment:
       secret_key_base: ''

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -14,8 +14,13 @@ namespace :users do
   end
   desc "Add admin status from an account, given an email"
   task :add_admin, [:email] => :environment do |t, args|
-    u = User.find_by_email(args[:email])
+    email = args[:email]
+    u = User.find_by_email(email)
     u.admin = true
-    u.save
+    if u.save
+      puts "Successfully granted admin status to #{email}."
+    else
+      puts "Granting admin status to #{email} failed."
+    end
   end
 end


### PR DESCRIPTION
Based on feedback from Rocket and Peter
- Separate docker-compose build and docker-compose up steps
- Clarify user adminification docs and make success successier (#168)
- Don't recommend docker-compose auto-restart in dev environments