### PR TITLE
Create CallTool module to handle rest interactions with call tool

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -10,7 +10,7 @@ class ToolsController < ApplicationController
   skip_before_filter :verify_authenticity_token, only: :petition
 
   def call_required_fields
-    render :json => CallCampaign.find(params[:call_campaign_id]).required_fields
+    render :json => CallTool.required_fields_for_campaign(params[:call_campaign_id])
   end
 
   def call
@@ -24,12 +24,12 @@ class ToolsController < ApplicationController
       update_user_data(call_params.with_indifferent_access)
     end
 
-    CallCampaign.find(params[:call_campaign_id]).
-      connect(phone: params[:phone],
-              location: params[:location],
-              user_id: @user.try(:id),
-              action_id: @action_page.to_param,
-              callback_url: root_url)
+    CallTool.campaign_call(params[:call_campaign_id],
+                           phone: params[:phone],
+                           location: params[:location],
+                           user_id: @user.try(:id),
+                           action_id: @action_page.to_param,
+                           callback_url: root_url)
 
     render :json => {}, :status => 200
   end

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -10,10 +10,7 @@ class ToolsController < ApplicationController
   skip_before_filter :verify_authenticity_token, only: :petition
 
   def call_required_fields
-    response = RestClient.get Rails.application.config.call_tool_url +
-      '/api/campaign/' + params[:call_campaign_id] +
-      '?api_key=' + Rails.application.secrets.call_tool_api_key
-    render :json => JSON.parse(response.body)["required_fields"]
+    render :json => CallCampaign.find(params[:call_campaign_id]).required_fields
   end
 
   def call
@@ -27,34 +24,12 @@ class ToolsController < ApplicationController
       update_user_data(call_params.with_indifferent_access)
     end
 
-    begin
-      response = RestClient.get Rails.application.config.call_tool_url + '/call/create',
-        params: { campaignId: params[:call_campaign_id],
-                  userPhone:  params[:phone],
-                  userCountry: 'US',
-                  userLocation: params[:location],
-                  # TODO - Settle on the schema of the private meta data
-                  meta: {
-                    user_id:     @user.try(:id),
-                    action_id:   params[:action_id],
-                    action_type: 'call'
-                  }.to_json,
-                  callback_url: root_url }
-    rescue RestClient::BadRequest => e
-      begin
-        error = JSON.parse(e.http_body)["error"]
-      rescue
-        raise e
-      end
-      # Don't raise for twilio error 13224: number invalid
-      unless error.match(/^13224:/)
-        if Rails.application.secrets.sentry_dsn.nil?
-          raise error
-        else
-          Raven.capture_message(error, { :level => 'info' })
-        end
-      end
-    end
+    CallCampaign.find(params[:call_campaign_id]).
+      connect(phone: params[:phone],
+              location: params[:location],
+              user_id: @user.try(:id),
+              action_id: @action_page.to_param,
+              callback_url: root_url)
 
     render :json => {}, :status => 200
   end

--- a/app/models/call_campaign.rb
+++ b/app/models/call_campaign.rb
@@ -1,14 +1,3 @@
-
-require "call_tool"
-
 class CallCampaign < ActiveRecord::Base
   has_one :action_page
-
-  def required_fields
-    CallTool.required_fields_for_campaign(self)
-  end
-
-  def connect(**kwargs)
-    CallTool.campaign_call(self, **kwargs)
-  end
 end

--- a/app/models/call_campaign.rb
+++ b/app/models/call_campaign.rb
@@ -1,2 +1,14 @@
+
+require "call_tool"
+
 class CallCampaign < ActiveRecord::Base
+  has_one :action_page
+
+  def required_fields
+    CallTool.required_fields_for_campaign(self)
+  end
+
+  def connect(**kwargs)
+    CallTool.campaign_call(self, **kwargs)
+  end
 end

--- a/lib/call_tool.rb
+++ b/lib/call_tool.rb
@@ -1,0 +1,58 @@
+require "rest_client"
+
+module CallTool
+  def self.campaign_call(campaign, phone:, location:, user_id:, action_id:, callback_url:)
+    unless [campaign, phone, location, action_id, callback_url].all?
+      raise ArgumentError.new("required argument is nil")
+    end
+
+    get "/call/create", {
+      campaignId: campaign.to_param,
+      userPhone:  phone,
+      userCountry: "US",
+      userLocation: location,
+      callback_url: callback_url,
+
+      # TODO - Settle on the schema of the private meta data
+      meta: {
+        user_id:     user_id,
+        action_id:   action_id,
+        action_type: "call"
+      }.to_json,
+    }
+  end
+
+  def self.required_fields_for_campaign(campaign)
+    response = get "/api/campaign/#{campaign.to_param}", { api_key: api_key }
+    JSON.parse(response.body)["required_fields"]
+  end
+
+  private
+
+  def self.get(action, params={})
+    RestClient.get endpoint(action), params: params
+  rescue RestClient::BadRequest => e
+    begin
+      error = JSON.parse(e.http_body)["error"]
+    rescue
+      raise
+    end
+
+    # Don't raise for twilio error 13224: number invalid
+    unless error.match(/^13224:/)
+      if Rails.application.secrets.sentry_dsn.nil?
+        raise error
+      else
+        Raven.capture_message(error, level: "info")
+      end
+    end
+  end
+
+  def self.endpoint(action)
+    "#{Rails.application.config.call_tool_url}#{action}"
+  end
+
+  def self.api_key
+    Rails.application.secrets.call_tool_api_key
+  end
+end

--- a/spec/controllers/tools_controller_spec.rb
+++ b/spec/controllers/tools_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'call_tool'
 
 RSpec.describe ToolsController, type: :controller do
 
@@ -44,6 +45,19 @@ RSpec.describe ToolsController, type: :controller do
     expect(@petition.signatures.count).to eq 100
   end
 
+  describe "#call" do
+    it "should CallTool#campaign_call, passing parameters in" do
+      call_campaign = FactoryGirl.create(:call_campaign)
+
+      expect(CallTool).to receive(:campaign_call)
+      post :call, {
+             phone: "000-000-0000",
+             location: "00000",
+             call_campaign_id: call_campaign.id,
+             action_id: call_campaign.action_page.id
+           }
+    end
+  end
 end
 
 def create_signature_and_have_user_sign

--- a/spec/factories/action_page.rb
+++ b/spec/factories/action_page.rb
@@ -17,4 +17,7 @@ FactoryGirl.define do
     enable_tweet true
   end
 
+  factory :action_page_with_call, :parent => :action_page do
+    enable_call true
+  end
 end

--- a/spec/factories/call_campaigns.rb
+++ b/spec/factories/call_campaigns.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :call_campaign do
+    after(:create) do |campaign|
+      FactoryGirl.create(:action_page_with_call, call_campaign_id: campaign.id)
+    end
+  end
+end

--- a/spec/lib/call_tool_spec.rb
+++ b/spec/lib/call_tool_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+require "call_tool"
+
+describe CallTool do
+  describe ".campaign_call" do
+    let(:campaign) { FactoryGirl.create(:call_campaign) }
+
+    let(:keywords) {
+      {
+        phone: "000-000-0000",
+        location: "00000",
+        user_id: 456,
+        action_id: 789,
+        callback_url: "/"
+      }
+    }
+
+    it "should get call_tool_url/call/create, transforming keyword arguments into params" do
+      expect(RestClient).to receive(:get) do |url, opts|
+        expect(url).to eq("#{Rails.application.config.call_tool_url}/call/create")
+        expect(opts[:params]).not_to be_nil
+        expect(opts[:params][:campaignId]).to eq(campaign.to_param)
+        expect(opts[:params][:userPhone]).to eq(keywords[:phone])
+        expect(opts[:params][:userCountry]).to eq("US")
+        expect(opts[:params][:userLocation]).to eq(keywords[:location])
+        expect(opts[:params][:callback_url]).to eq(keywords[:callback_url])
+        expect(opts[:params][:meta]).to eq({ user_id: keywords[:user_id],
+                                             action_id: keywords[:action_id],
+                                             action_type: "call" }.to_json)
+      end
+
+      CallTool.campaign_call(campaign, **keywords)
+    end
+
+    it "should raise ArgumentError if a required param is missing" do
+      allow(RestClient).to receive(:get)
+
+      expect{
+        CallTool.campaign_call(nil, **keywords)
+      }.to raise_error(ArgumentError)
+
+      expect{
+        CallTool.campaign_call(campaign, **keywords.dup.tap{ |x| x[:phone] = nil })
+      }.to raise_error(ArgumentError)
+
+      expect{
+        CallTool.campaign_call(campaign, **keywords.dup.tap{ |x| x[:location] = nil })
+      }.to raise_error(ArgumentError)
+
+      expect{
+        CallTool.campaign_call(campaign, **keywords.dup.tap{ |x| x[:action_id] = nil })
+      }.to raise_error(ArgumentError)
+
+      expect{
+        CallTool.campaign_call(campaign, **keywords.dup.tap{ |x| x[:callback_url] = nil })
+      }.to raise_error(ArgumentError)
+
+      expect{
+        CallTool.campaign_call(campaign, **keywords.dup.tap{ |x| x[:user_id] = nil })
+      }.not_to raise_error
+    end
+
+    it "should not raise any errors for twilio 'number invalid' error" do
+      exception = RestClient::BadRequest.new
+      expect(exception).to receive(:http_body){ %({"error": "13224: number invalid"}) }
+      expect(RestClient).to receive(:get).and_raise(exception)
+
+      expect(Raven).not_to receive(:capture_message)
+      expect{ CallTool.campaign_call(campaign, **keywords) }.not_to raise_exception
+    end
+  end
+
+  describe ".required_fields_for_campaign" do
+    it "should get call_tool_url/api/campaign/:id with the call tool api key" do
+      campaign = 12345
+      expect(RestClient).to receive(:get) do |url, opts|
+        expect(url).to eq("#{Rails.application.config.call_tool_url}/api/campaign/#{campaign}")
+        expect(opts[:params][:api_key]).to eq(Rails.application.secrets.call_tool_api_key)
+        OpenStruct.new(body: {required_fields: { userLocation: "postal", userPhone: "US" } }.to_json)
+      end
+
+      CallTool.required_fields_for_campaign(campaign)
+    end
+  end
+end


### PR DESCRIPTION
This branch encapsulates interactions with the call tool api in a new module named `CallTool` (addressing #176). Please note that it's untested since I'm not able to hit the api endpoint in development.