### PR TITLE
Revert "Precompile assets on Docker build"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,13 +34,5 @@ ADD spec/ ./spec
 ADD vendor/ ./vendor
 ADD docker/ ./docker
 
-RUN bundle exec rake assets:precompile --silent \
-  RAILS_ENV=production \
-  SECRET_KEY_BASE=noop \
-  devise_secret_key=noop \
-  DATABASE_URL=postgres://noop \
-  2>&1 | grep -v INFO
-RUN bundle exec rake webshims:update_public
-
 CMD ["rails", "s", "-b", "0.0.0.0"]
 ENTRYPOINT ["/opt/actioncenter/docker/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,8 @@ if [ "$TESTDB_ENV_AUTO_MIGRATE" == "yes" ]; then
   bin/rake db:migrate RAILS_ENV=test
 fi
 
+bin/rake webshims:update_public
+
 # host ip needed by application for better_errors whitelisting to work
 export HOST_IP=`/sbin/ip route|awk '/default/ { print $3 }'`
 


### PR DESCRIPTION
Too many environment variables are required by our javascript files.