### PR TITLE
Petition signature deletion

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -107,6 +107,10 @@ $(document).on('ready', function() {
     history.pushState(null,null,'#' + anchor);
   });
 
+  $(".container input[type=checkbox].select-all").click(function(e) {
+    $(this).parents("form").find("input[type=checkbox]").prop("checked", this.checked);
+  });
+
   var updated_at = $('#action_page_updated_at');
   if (updated_at.length > 0) {
     var t = window.setInterval(function() {

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -8,6 +8,7 @@
 //= require admin/file_uploads
 //= require admin/s3_uploads.js
 //= require admin/email_tabulation
+//= require admin/petitions
 //= require s3_cors_fileupload
 //= require bootstrap-sass/bootstrap/tab
 //= require bootstrap-responsive-tabs
@@ -105,10 +106,6 @@ $(document).on('ready', function() {
     var anchor = $(e.target).data('tab');
     $('#anchor').val(anchor);
     history.pushState(null,null,'#' + anchor);
-  });
-
-  $(".container input[type=checkbox].select-all").click(function(e) {
-    $(this).parents("form").find("input[type=checkbox]").prop("checked", this.checked);
   });
 
   var updated_at = $('#action_page_updated_at');

--- a/app/assets/javascripts/admin/petitions.js
+++ b/app/assets/javascripts/admin/petitions.js
@@ -1,0 +1,6 @@
+$(document).ready(function() {
+  $("body.petitions-show input[type=checkbox].select-all").click(function(e) {
+    $(this).parents("form").find("input[type=checkbox]").prop("checked", this.checked);
+  });
+});
+

--- a/app/assets/stylesheets/admin/_petitions.css.scss
+++ b/app/assets/stylesheets/admin/_petitions.css.scss
@@ -1,0 +1,24 @@
+
+body.petitions-show {
+  form#filter_petitions {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 8px;
+
+    input[type=text] {
+      flex: 1 0;
+    }
+
+    input[type=submit] {
+      margin-left: 8px;
+    }
+  }
+
+  table td:last-child {
+    text-align: center;
+  }
+
+  table input[type=checkbox] {
+    float: none;
+  }
+}

--- a/app/assets/stylesheets/admin/_petitions.css.scss
+++ b/app/assets/stylesheets/admin/_petitions.css.scss
@@ -14,7 +14,7 @@ body.petitions-show {
     }
   }
 
-  table td:last-child {
+  table td:last-child, table th:last-child {
     text-align: center;
   }
 

--- a/app/assets/stylesheets/admin/admin.css.scss
+++ b/app/assets/stylesheets/admin/admin.css.scss
@@ -34,6 +34,7 @@
 @import "admin/email_campaigns";
 @import "admin/image_upload";
 @import "admin/partners";
+@import "admin/petitions";
 
 @import "bootstrap-daterangepicker/daterangepicker-bs3";
 

--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -1,10 +1,9 @@
 include PetitionHelper
 class Admin::PetitionsController < Admin::ApplicationController
   before_action :set_petition
+
   def show
-    @signatures = @petition.signatures.
-      paginate(:page => params[:page], :per_page => 10).
-      order('id desc')
+    @signatures = filtered_signatures
   end
 
   # This file will wind up at CiviCRM
@@ -28,8 +27,26 @@ class Admin::PetitionsController < Admin::ApplicationController
     render layout: 'report'
   end
 
+  def destroy_signatures
+    @petition.signatures.where(id: params[:signature_ids]).delete_all
+
+    if params[:page].to_i > filtered_signatures.total_pages
+      params[:page] = filtered_signatures.total_pages
+    end
+
+    redirect_to admin_petition_path(@petition, params.slice(:query, :page))
+  end
+
   private
+
   def set_petition
     @petition = Petition.find(params[:id])
+  end
+
+  def filtered_signatures
+    @petition.signatures.
+      filter(params[:query]).
+      order(created_at: :desc).
+      paginate(page: params[:page], per_page: 10)
   end
 end

--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -34,7 +34,7 @@ class Admin::PetitionsController < Admin::ApplicationController
       params[:page] = filtered_signatures.total_pages
     end
 
-    redirect_to admin_petition_path(@petition, params.slice(:query, :page))
+    redirect_to admin_petition_path(@petition, params.slice(:query, :page, :per_page))
   end
 
   private
@@ -47,6 +47,6 @@ class Admin::PetitionsController < Admin::ApplicationController
     @petition.signatures.
       filter(params[:query]).
       order(created_at: :desc).
-      paginate(page: params[:page], per_page: 10)
+      paginate(page: params[:page], per_page: params[:per_page] || 10)
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -18,6 +18,16 @@ class Signature < ActiveRecord::Base
 
   accepts_nested_attributes_for :affiliations, reject_if: :all_blank
 
+  scope :filter, ->(f) do
+    if f.present?
+      where("LOWER(email) LIKE ? " +
+            "OR LOWER(first_name || ' ' || last_name) LIKE ?",
+            "%#{f}%".downcase, "%#{f}%".downcase)
+    else
+      all
+    end
+  end
+
   include ActionView::Helpers::DateHelper
 
   def self.pretty_count

--- a/app/views/admin/petitions/show.html.erb
+++ b/app/views/admin/petitions/show.html.erb
@@ -18,7 +18,8 @@
 
   <% unless signatures_count.zero? %>
     <%= form_tag admin_petition_path(@petition), id: "filter_petitions", method: "get" do %>
-      <%= text_field_tag :query, params[:query], placeholder: "Filter by name or email...", class: "form-control input-sm" %>
+      <%= label_tag :query, "Filter by name or e-mail", class: "sr-only" %>
+      <%= text_field_tag :query, params[:query], placeholder: "Filter by name or email", class: "form-control input-sm" %>
       <%= submit_tag "Search", class: "btn btn-sm btn-default" %>
     <% end %>
 
@@ -39,7 +40,10 @@
                 <td><em><%= "#{signature.first_name} #{signature.last_name}" %></em></td>
                 <td><em><%= signature.email %></em></td>
                 <td class="timeago" title="<%= signature.created_at.to_time.iso8601 %>"><%= signature.created_at.to_time.iso8601 %></td>
-                <td><input type="checkbox" name="signature_ids[]" value="<%= signature.id %>" title="Select for deletion" /></td>
+                <td>
+                  <input type="checkbox" name="signature_ids[]" value="<%= signature.id %>"
+                         title="<%= "Select #{signature.first_name} #{signature.last_name} for deletion" %>">
+                </td>
               </tr>
             <% end %>
 

--- a/app/views/admin/petitions/show.html.erb
+++ b/app/views/admin/petitions/show.html.erb
@@ -18,7 +18,7 @@
 
   <% unless signatures_count.zero? %>
     <%= form_tag admin_petition_path(@petition), id: "filter_petitions", method: "get" do %>
-      <%= text_field_tag :query, params[:query], placeholder: "Filter by name, email, institution..." %>
+      <%= text_field_tag :query, params[:query], placeholder: "Filter by name or email..." %>
       <%= submit_tag "Search" %>
     <% end %>
 

--- a/app/views/admin/petitions/show.html.erb
+++ b/app/views/admin/petitions/show.html.erb
@@ -22,19 +22,18 @@
       <%= submit_tag "Search", class: "btn btn-sm btn-default" %>
     <% end %>
 
-    <%= form_tag signatures_admin_petition_path(@petition, params.slice(:query, :page, :per_page)), method: :delete do %>
-      <table class="table table-striped table-hover ">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Signed</th>
-            <th><input type="checkbox" class="select-all" title="Select all" /></th>
-          </tr>
-        </thead>
-        <tbody>
-
-          <% if @signatures.exists? %>
+    <% if @signatures.exists? %>
+      <%= form_tag signatures_admin_petition_path(@petition, params.slice(:query, :page, :per_page)), method: :delete do %>
+        <table class="table table-striped table-hover ">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Signed</th>
+              <th><input type="checkbox" class="select-all" title="Select all" /></th>
+            </tr>
+          </thead>
+          <tbody>
             <% @signatures.each do |signature| %>
               <tr>
                 <td><em><%= "#{signature.first_name} #{signature.last_name}" %></em></td>
@@ -50,11 +49,11 @@
                 <%= submit_tag "Delete Selected", class: "btn btn-danger btn-sm" %>
               </td>
             </tr>
-          <% else %>
-            <tr>No signatures match this query</tr>
-          <% end %>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      <% end %>
+    <% else %>
+      <strong>No signatures match this query</strong>
     <% end %>
 
     <%= will_paginate @signatures -%>

--- a/app/views/admin/petitions/show.html.erb
+++ b/app/views/admin/petitions/show.html.erb
@@ -22,7 +22,7 @@
       <%= submit_tag "Search" %>
     <% end %>
 
-    <%= form_tag signatures_admin_petition_path(@petition, query: params[:query], page: params[:page] || '1'), method: :delete do %>
+    <%= form_tag signatures_admin_petition_path(@petition, params.slice(:query, :page)), method: :delete do %>
       <table class="table table-striped table-hover ">
         <tbody>
 

--- a/app/views/admin/petitions/show.html.erb
+++ b/app/views/admin/petitions/show.html.erb
@@ -9,22 +9,51 @@
     <strong>Text:</strong>
     <%= markdown @petition.description %>
   </p>
-  <h3 class='clearfix'>
-      <%= @petition.signatures.count -%> Signatures
-      <%= link_to 'Download CSV', csv_admin_petition_path(@petition), class: 'btn btn-default btn-sm pull-right'-%>
-  </h3>
-  <table class="table table-striped table-hover ">
-    <tbody>
-   <% @signatures.each do |signature| %>
 
-      <tr>
-        <td><em><%= "#{signature.first_name} #{signature.last_name}" %></em></td>
-        <td><em><%= signature.email %></em></td>
-        <td class="timeago" title="<%= signature.created_at.to_time.iso8601 %>"><%= signature.created_at.to_time.iso8601 %></td>
-      </tr>
+  <% signatures_count = @petition.signatures.count %>
+  <h3 class="clearfix">
+    <%= signatures_count -%> Signatures
+    <%= link_to "Download CSV", csv_admin_petition_path(@petition), class: "btn btn-default btn-sm pull-right"-%>
+  </h3>
+
+  <% unless signatures_count.zero? %>
+    <%= form_tag admin_petition_path(@petition), id: "filter_petitions", method: "get" do %>
+      <%= text_field_tag :query, params[:query], placeholder: "Filter by name, email, institution..." %>
+      <%= submit_tag "Search" %>
     <% end %>
 
-    </tbody>
-  </table>
-  <%= will_paginate @signatures -%>
+    <%= form_tag signatures_admin_petition_path(@petition, query: params[:query], page: params[:page] || '1'), method: :delete do %>
+      <table class="table table-striped table-hover ">
+        <tbody>
+
+          <% if @signatures.exists? %>
+            <% @signatures.each do |signature| %>
+              <tr>
+                <td><em><%= "#{signature.first_name} #{signature.last_name}" %></em></td>
+                <td><em><%= signature.email %></em></td>
+                <td class="timeago" title="<%= signature.created_at.to_time.iso8601 %>"><%= signature.created_at.to_time.iso8601 %></td>
+                <td><input type="checkbox" name="signature_ids[]" value="<%= signature.id %>" /></td>
+              </tr>
+            <% end %>
+
+            <tr>
+              <td colspan="3"></td>
+              <td><input type="checkbox" class="select-all" title="Select all" /></td>
+            </tr>
+
+            <tr>
+              <td colspan="3"></td>
+              <td align="center">
+                <%= submit_tag "Destroy", class: "btn btn-default btn-cancel btn-sm" %>
+              </td>
+            </tr>
+          <% else %>
+            <tr>No signatures match this query</tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+
+    <%= will_paginate @signatures -%>
+  <% end %>
 </div>

--- a/app/views/admin/petitions/show.html.erb
+++ b/app/views/admin/petitions/show.html.erb
@@ -22,7 +22,7 @@
       <%= submit_tag "Search" %>
     <% end %>
 
-    <%= form_tag signatures_admin_petition_path(@petition, params.slice(:query, :page)), method: :delete do %>
+    <%= form_tag signatures_admin_petition_path(@petition, params.slice(:query, :page, :per_page)), method: :delete do %>
       <table class="table table-striped table-hover ">
         <tbody>
 

--- a/app/views/admin/petitions/show.html.erb
+++ b/app/views/admin/petitions/show.html.erb
@@ -18,12 +18,20 @@
 
   <% unless signatures_count.zero? %>
     <%= form_tag admin_petition_path(@petition), id: "filter_petitions", method: "get" do %>
-      <%= text_field_tag :query, params[:query], placeholder: "Filter by name or email..." %>
-      <%= submit_tag "Search" %>
+      <%= text_field_tag :query, params[:query], placeholder: "Filter by name or email...", class: "form-control input-sm" %>
+      <%= submit_tag "Search", class: "btn btn-sm btn-default" %>
     <% end %>
 
     <%= form_tag signatures_admin_petition_path(@petition, params.slice(:query, :page, :per_page)), method: :delete do %>
       <table class="table table-striped table-hover ">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Signed</th>
+            <th><input type="checkbox" class="select-all" title="Select all" /></th>
+          </tr>
+        </thead>
         <tbody>
 
           <% if @signatures.exists? %>
@@ -32,19 +40,14 @@
                 <td><em><%= "#{signature.first_name} #{signature.last_name}" %></em></td>
                 <td><em><%= signature.email %></em></td>
                 <td class="timeago" title="<%= signature.created_at.to_time.iso8601 %>"><%= signature.created_at.to_time.iso8601 %></td>
-                <td><input type="checkbox" name="signature_ids[]" value="<%= signature.id %>" /></td>
+                <td><input type="checkbox" name="signature_ids[]" value="<%= signature.id %>" title="Select for deletion" /></td>
               </tr>
             <% end %>
 
             <tr>
               <td colspan="3"></td>
-              <td><input type="checkbox" class="select-all" title="Select all" /></td>
-            </tr>
-
-            <tr>
-              <td colspan="3"></td>
               <td align="center">
-                <%= submit_tag "Destroy", class: "btn btn-default btn-cancel btn-sm" %>
+                <%= submit_tag "Delete Selected", class: "btn btn-danger btn-sm" %>
               </td>
             </tr>
           <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Actioncenter::Application.routes.draw do
         get :csv
         get :presentable_csv
         get '/:bioguide_id' => 'petitions#report'
+        delete "signatures" => "petitions#destroy_signatures", as: :signatures
       end
     end
 

--- a/features/admin/petitions/delete_signatures.feature
+++ b/features/admin/petitions/delete_signatures.feature
@@ -9,11 +9,11 @@ Feature: Delete petition signatures
 
   Scenario:
     When I visit the signatures list
-    When I select some signatures
-    When I click destroy
+    And I select some signatures
+    And I click to delete the selected signatures
     Then the selected signatures are destroyed
 
   Scenario:
     When I visit the signatures list
-    When I click the select all checkbox
+    And I click the select all checkbox
     Then all signatures are selected

--- a/features/admin/petitions/delete_signatures.feature
+++ b/features/admin/petitions/delete_signatures.feature
@@ -1,0 +1,19 @@
+@javascript
+Feature: Delete petition signatures
+  An admin should be able to delete petition signatures
+
+  Background:
+    Given I exist as an activist
+    And I am logged in
+    And a petition exists with many signatures
+
+  Scenario:
+    When I visit the signatures list
+    When I select some signatures
+    When I click destroy
+    Then the selected signatures are destroyed
+
+  Scenario:
+    When I visit the signatures list
+    When I click the select all checkbox
+    Then all signatures are selected

--- a/features/admin/petitions/search_signatures.feature
+++ b/features/admin/petitions/search_signatures.feature
@@ -1,0 +1,18 @@
+@javascript
+Feature: Search petition signatures
+  An admin should be able to search petition signatures
+
+  Background:
+    Given I exist as an activist
+    And I am logged in
+    And a petition exists with many signatures
+
+  Scenario:
+    When I visit the signatures list
+    When I search for an email in the petitions list
+    Then the matching signatures should be in the results
+
+  Scenario:
+    When I visit the signatures list
+    When I search for an email not in the petitions list
+    Then there should be no matching signatures

--- a/features/step_definitions/admin/features_steps.rb
+++ b/features/step_definitions/admin/features_steps.rb
@@ -36,8 +36,8 @@ When(/^I select some signatures$/) do
   end.map(&:to_i)
 end
 
-When(/^I click destroy$/) do
-  find("input[type=submit][value=Destroy]").click
+When(/^I click to delete the selected signatures$/) do
+  find("input[type=submit][value=Delete\\ Selected]").click
 end
 
 Then(/^the selected signatures are destroyed$/) do

--- a/features/step_definitions/admin/features_steps.rb
+++ b/features/step_definitions/admin/features_steps.rb
@@ -1,0 +1,54 @@
+
+
+Given(/^a petition exists with many signatures$/) do
+  @petition = FactoryGirl.create(:petition_complete_with_one_hundred_signatures)
+end
+
+When(/^I visit the signatures list$/) do
+  visit "/admin/petitions/#{@petition.id}"
+end
+
+When(/^I search for an email in the petitions list$/) do
+  @matching_signature = @petition.signatures.order(:created_at).last
+
+  find("input[name=query]").set(@matching_signature.email)
+  find("input[type=submit][value=Search]").click
+end
+
+When(/^I search for an email not in the petitions list$/) do
+  find("input[name=query]").set("this filter should not match anything")
+  find("input[type=submit][value=Search]").click
+end
+
+Then(/^the matching signatures should be in the results$/) do
+  expect(page).to have_content(@matching_signature.email)
+end
+
+Then(/^there should be no matching signatures$/) do
+  expect(page).to have_content("No signatures match this query")
+end
+
+When(/^I select some signatures$/) do
+  @selected_signature_ids = 4.times.map do
+    checkbox = first("input[name=signature_ids\\[\\]]:not(:checked)")
+    checkbox.set(true)
+    checkbox.value
+  end.map(&:to_i)
+end
+
+When(/^I click destroy$/) do
+  find("input[type=submit][value=Destroy]").click
+end
+
+Then(/^the selected signatures are destroyed$/) do
+  page.has_css?(".container") # this causes capybara to wait until action is complete
+  expect(Signature.where(id: @selected_signature_ids)).to be_empty
+end
+
+When(/^I click the select all checkbox$/) do
+  find("input[type=checkbox].select-all").click
+end
+
+Then(/^all signatures are selected$/) do
+  expect(first("input[name=signature_ids\\[\\]]:not(:checked)")).to be_nil
+end

--- a/spec/controllers/admin/petitions_controller_spec.rb
+++ b/spec/controllers/admin/petitions_controller_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe Admin::PetitionsController, type: :controller do
+  include Devise::TestHelpers
+
+  before(:each) do
+    @request.env["devise.mapping"] = Devise.mappings[:admin]
+    sign_in FactoryGirl.create(:admin_user)
+  end
+
+  describe "GET #show" do
+    let(:petition){ FactoryGirl.create(:petition) }
+
+    it "assigns @signatures" do
+      get :show, id: petition.id
+      expect(assigns(:signatures)).not_to be_nil
+      expect(response.status).to eq(200)
+    end
+
+    it "passes the 'query' param through Signature.filter" do
+      query = "jo@example.com"
+
+      expect(Petition).to receive(:find){ petition }
+      expect(petition.signatures).to receive(:filter) do |q|
+        expect(q).to eq(query)
+        Signature.all
+      end
+
+      get :show, id: petition.id, query: query
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "DELETE #destroy_signatures" do
+    let(:petition){ FactoryGirl.create(:petition) }
+    let(:signatures) do
+      30.times.map do
+        petition.signatures.create(
+          first_name: "Save Kittens",
+          last_name: "Save kittens in great detail",
+          email: "johnsmith@eff.org",
+          country_code: "US",
+          zipcode: "94109",
+          street_address: "815 Eddy Street",
+          city: "San Francisco",
+          state: "CA",
+          anonymous: false
+        )
+      end
+    end
+
+    it "should delete signatures from the signature_ids param" do
+      delete :destroy_signatures, id: petition.id, signature_ids: signatures[10..-1].map(&:id)
+      expect(petition.signatures.reload).to contain_exactly(*signatures[0..9])
+      expect(response).to redirect_to(admin_petition_path(petition))
+    end
+
+    it "should redirect back to the same page (or earlier if that page is deleted)" do
+      signatures
+      delete :destroy_signatures, id: petition.id, signature_ids: [], query: "", page: 2
+      expect(response).to redirect_to(admin_petition_path(petition, query: "", page: 2))
+
+      # there is no page 4, so we expect a redirect to page 3
+      delete :destroy_signatures, id: petition.id, signature_ids: [], query: "", page: 4
+      expect(response).to redirect_to(admin_petition_path(petition, query: "", page: 3))
+    end
+  end
+end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -46,4 +46,32 @@ describe Signature do
     }.to raise_error ActiveRecord::RecordInvalid
   end
 
+  describe ".filter" do
+    let(:jon){ Signature.create!(@attr.merge(email: "xx@example.com", first_name: "Jon", last_name: "A")) }
+    let(:jan){ Signature.create!(@attr.merge(email: "xy@example.com", first_name: "Jan", last_name: "B")) }
+    let(:jeb){ Signature.create!(@attr.merge(email: "wz@example.com", first_name: "Jeb", last_name: "C")) }
+    let(:jen){ Signature.create!(@attr.merge(email: "wv@example.com", first_name: "Jen", last_name: "D")) }
+
+    let(:all_signatures){ [jon, jan, jeb, jen] }
+
+    it "should return .all when query is blank" do
+      expect(Signature.filter(nil)).to contain_exactly(*all_signatures)
+      expect(Signature.filter("")).to contain_exactly(*all_signatures)
+      expect(Signature.filter("    \t")).to contain_exactly(*all_signatures)
+    end
+
+    it "should return signatures with matching email (case insensitive)" do
+      expect(Signature.filter("example.com")).to contain_exactly(*all_signatures)
+      expect(Signature.filter("EXAMPLE")).to contain_exactly(*all_signatures)
+      expect(Signature.filter("w")).to contain_exactly(jeb, jen)
+      expect(Signature.filter("xx")).to contain_exactly(jon)
+    end
+
+    it "should return signatures with matching names (case insensitive)" do
+      expect(Signature.filter("J")).to contain_exactly(*all_signatures)
+      expect(Signature.filter("Jon")).to contain_exactly(jon)
+      expect(Signature.filter("Jan B")).to contain_exactly(jan)
+      expect(Signature.filter("Jeb c")).to contain_exactly(jeb)
+    end
+  end
 end


### PR DESCRIPTION
This branch adds a search feature to the page on `/admin/petitions/:id` so that signatures with a particular name or email can be listed. The search is case insensitive and allows for partial matches. It also provides a button on that page for deleting signatures, fixing #188.