### PR TITLE
Kill CGI::escape

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -162,25 +162,11 @@ class ToolsController < ApplicationController
         { type: "action", actionType: "email", actionPageId: params[:action_id] },
         action_page: @action_page
     end
-    subject_uri = URI::escape @action_page.email_campaign.subject
-    subject_cgi = CGI::escape @action_page.email_campaign.subject
-    body_uri = URI::escape @action_page.email_campaign.message
-    body_cgi = CGI::escape @action_page.email_campaign.message
-    body_hotmail = CGI::escape @action_page.email_campaign.message.gsub("\r\n","<br>")
-    to_cgi = CGI::escape @action_page.email_campaign.email_addresses.gsub(" ","")
-    case params[:service]
-    when "default"
-      redirect_to "mailto:" + to_cgi + "?subject=" + subject_uri + "&body=" + body_uri
-    when "gmail"
-      redirect_to "https://mail.google.com/mail/?view=cm&fs=1&to=" + to_cgi + "&su=" + subject_cgi + "&body=" + body_cgi
-    when "yahoo"
-      # couldn't get newlines to work here, see: https://stackoverflow.com/questions/1632335/uri-encoding-in-yahoo-mail-compose-link
-      redirect_to "http://compose.mail.yahoo.com/?to=" + to_cgi + "&subj=" + subject_cgi + "&body=" + body_cgi
-    when "hotmail"
-      redirect_to "https://mail.live.com/default.aspx?rru=compose&to=" + to_cgi + "&subject=" + subject_cgi + "&body=" + body_hotmail
-    when "copy"
+
+    if params[:service] == "copy"
       @actionPage = @action_page
-      render
+    else
+      redirect_to @action_page.email_campaign.service_uri(params[:service])
     end
   end
 

--- a/app/helpers/action_page_helper.rb
+++ b/app/helpers/action_page_helper.rb
@@ -12,7 +12,7 @@ module ActionPageHelper
 
     related = Rails.application.config.twitter_related.to_a.join(',')
 
-    "https://twitter.com/intent/tweet?status=#{CGI::escape message}&related=#{related}"
+    "https://twitter.com/intent/tweet?status=#{u message}&related=#{related}"
   end
 
   def google_share_url(action_page)
@@ -23,7 +23,7 @@ module ActionPageHelper
     target = "@#{target}" unless target.starts_with? '@'
     message = [target, message].compact.join(' ')
     related = Rails.application.config.twitter_related.to_a.join(',')
-    "https://twitter.com/intent/tweet?status=.#{CGI::escape message}&related=#{related}"
+    "https://twitter.com/intent/tweet?status=.#{u message}&related=#{related}"
   end
 
   def facebook_share_url(action_page)
@@ -34,7 +34,7 @@ module ActionPageHelper
     subject = t('email_friends.subject')
     message = t('email_friends.message', title: action_page.title, url: action_page_url(action_page))
 
-    "mailto:?subject=#{CGI::escape subject}&body=#{CGI::escape message}"
+    "mailto:?subject=#{u subject}&body=#{u message}"
   end
 
   def rep_photo_src(bioguide_id)

--- a/app/models/email_campaign.rb
+++ b/app/models/email_campaign.rb
@@ -32,18 +32,25 @@ class EmailCampaign < ActiveRecord::Base
     message_brs = message.gsub("\r\n", "<br>")
 
     {
-      default: "mailto:#{to_cgi}?" + { subject: subject, body: message }.to_query,
+      default: "mailto:#{to_cgi}?#{query(subject: subject, body: message)}",
 
-      gmail: "https://mail.google.com/mail/?view=cm&fs=1&to=#{to_cgi}&" + { su: subject, body: message }.to_query,
+      gmail: "https://mail.google.com/mail/?view=cm&fs=1&to=#{to_cgi}&#{query(su: subject, body: message)}",
 
       # couldn't get newlines to work here, see: https://stackoverflow.com/questions/1632335/uri-encoding-in-yahoo-mail-compose-link
-      yahoo: "http://compose.mail.yahoo.com/?to=#{to_cgi}&" + { subj: subject, body: message }.to_query,
+      yahoo: "http://compose.mail.yahoo.com/?to=#{to_cgi}&#{query(subj: subject, body: message)}",
 
-      hotmail: "https://outlook.live.com/default.aspx?rru=compose&to=#{to_cgi}&" + { subject: subject, body: message_brs }.to_query + "#page=Compose"
+      hotmail: "https://outlook.live.com/default.aspx?rru=compose&to=#{to_cgi}&#{query(subject: subject, body: message_brs)}#page=Compose"
     }.with_indifferent_access.fetch(service)
   end
 
   private
+
+  # like Hash#to_query except we percent encode spaces
+  def query(hash)
+    hash.collect do |key, value|
+      "#{u(key)}=#{u(value)}"
+    end.compact.sort! * '&'
+  end
 
   def target_bioguide_text_or_default custom_text, default
     if not target_bioguide_id or custom_text.blank?

--- a/app/models/email_campaign.rb
+++ b/app/models/email_campaign.rb
@@ -1,5 +1,6 @@
 class EmailCampaign < ActiveRecord::Base
   belongs_to :topic_category
+  has_one :action_page
 
   def email_your_rep_text default
     target_bioguide_text_or_default alt_text_email_your_rep, default

--- a/app/models/email_campaign.rb
+++ b/app/models/email_campaign.rb
@@ -25,21 +25,21 @@ class EmailCampaign < ActiveRecord::Base
   include ERB::Util
 
   def service_uri(service)
-    to_cgi = email_addresses.split(/\s*,\s*/).map do |email|
+    mailto_addresses = email_addresses.split(/\s*,\s*/).map do |email|
       u(email.gsub(" ", "")).gsub("%40", "@")
     end.join(",")
 
     message_brs = message.gsub("\r\n", "<br>")
 
     {
-      default: "mailto:#{to_cgi}?#{query(subject: subject, body: message)}",
+      default: "mailto:#{mailto_addresses}?#{query(body: message, subject: subject)}",
 
-      gmail: "https://mail.google.com/mail/?view=cm&fs=1&to=#{to_cgi}&#{query(su: subject, body: message)}",
+      gmail: "https://mail.google.com/mail/?view=cm&fs=1&#{query(to: email_addresses, body: message, su: subject)}",
 
       # couldn't get newlines to work here, see: https://stackoverflow.com/questions/1632335/uri-encoding-in-yahoo-mail-compose-link
-      yahoo: "http://compose.mail.yahoo.com/?to=#{to_cgi}&#{query(subj: subject, body: message)}",
+      yahoo: "http://compose.mail.yahoo.com/?#{query(to: email_addresses, subj: subject, body: message)}",
 
-      hotmail: "https://outlook.live.com/default.aspx?rru=compose&to=#{to_cgi}&#{query(subject: subject, body: message_brs)}#page=Compose"
+      hotmail: "https://outlook.live.com/default.aspx?rru=compose&#{query(to: email_addresses, body: message_brs, subject: subject)}#page=Compose"
     }.with_indifferent_access.fetch(service)
   end
 

--- a/app/models/email_campaign.rb
+++ b/app/models/email_campaign.rb
@@ -32,12 +32,12 @@ class EmailCampaign < ActiveRecord::Base
     {
       default: "mailto:#{mailto_addresses}?#{query(body: message, subject: subject)}",
 
-      gmail: "https://mail.google.com/mail/?view=cm&fs=1&#{query(to: email_addresses, body: message, su: subject)}",
+      gmail: "https://mail.google.com/mail/?view=cm&fs=1&#{{ to: email_addresses, body: message, su: subject }.to_query}",
 
       # couldn't get newlines to work here, see: https://stackoverflow.com/questions/1632335/uri-encoding-in-yahoo-mail-compose-link
-      yahoo: "http://compose.mail.yahoo.com/?#{query(to: email_addresses, subj: subject, body: message)}",
+      yahoo: "https://compose.mail.yahoo.com/?#{{ to: email_addresses, subj: subject, body: message }.to_query}",
 
-      hotmail: "https://outlook.live.com/default.aspx?rru=compose&#{query(to: email_addresses, body: message, subject: subject)}#page=Compose"
+      hotmail: "https://outlook.live.com/default.aspx?rru=compose&#{{ to: email_addresses, body: message, subject: subject }.to_query}#page=Compose"
     }.with_indifferent_access.fetch(service)
   end
 

--- a/app/models/email_campaign.rb
+++ b/app/models/email_campaign.rb
@@ -29,8 +29,6 @@ class EmailCampaign < ActiveRecord::Base
       u(email.gsub(" ", "")).gsub("%40", "@")
     end.join(",")
 
-    message_brs = message.gsub("\r\n", "<br>")
-
     {
       default: "mailto:#{mailto_addresses}?#{query(body: message, subject: subject)}",
 
@@ -39,7 +37,7 @@ class EmailCampaign < ActiveRecord::Base
       # couldn't get newlines to work here, see: https://stackoverflow.com/questions/1632335/uri-encoding-in-yahoo-mail-compose-link
       yahoo: "http://compose.mail.yahoo.com/?#{query(to: email_addresses, subj: subject, body: message)}",
 
-      hotmail: "https://outlook.live.com/default.aspx?rru=compose&#{query(to: email_addresses, body: message_brs, subject: subject)}#page=Compose"
+      hotmail: "https://outlook.live.com/default.aspx?rru=compose&#{query(to: email_addresses, body: message, subject: subject)}#page=Compose"
     }.with_indifferent_access.fetch(service)
   end
 

--- a/app/models/email_campaign.rb
+++ b/app/models/email_campaign.rb
@@ -49,7 +49,7 @@ class EmailCampaign < ActiveRecord::Base
   def query(hash)
     hash.collect do |key, value|
       "#{u(key)}=#{u(value)}"
-    end.compact.sort! * '&'
+    end.compact * '&'
   end
 
   def target_bioguide_text_or_default custom_text, default

--- a/app/models/email_campaign.rb
+++ b/app/models/email_campaign.rb
@@ -21,6 +21,27 @@ class EmailCampaign < ActiveRecord::Base
     target_bioguide_text_or_default alt_text_extra_fields_explain, default
   end
 
+  include ERB::Util
+
+  def service_uri(service)
+    to_cgi = email_addresses.split(/\s*,\s*/).map do |email|
+      u(email.gsub(" ", "")).gsub("%40", "@")
+    end.join(",")
+
+    message_brs = message.gsub("\r\n", "<br>")
+
+    {
+      default: "mailto:#{to_cgi}?" + { subject: subject, body: message }.to_query,
+
+      gmail: "https://mail.google.com/mail/?view=cm&fs=1&to=#{to_cgi}&" + { su: subject, body: message }.to_query,
+
+      # couldn't get newlines to work here, see: https://stackoverflow.com/questions/1632335/uri-encoding-in-yahoo-mail-compose-link
+      yahoo: "http://compose.mail.yahoo.com/?to=#{to_cgi}&" + { subj: subject, body: message }.to_query,
+
+      hotmail: "https://outlook.live.com/default.aspx?rru=compose&to=#{to_cgi}&" + { subject: subject, body: message_brs }.to_query + "#page=Compose"
+    }.with_indifferent_access.fetch(service)
+  end
+
   private
 
   def target_bioguide_text_or_default custom_text, default

--- a/spec/controllers/tools_controller_spec.rb
+++ b/spec/controllers/tools_controller_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe ToolsController, type: :controller do
            }
     end
   end
+
+  describe "#email_target" do
+    let(:email_campaign){ FactoryGirl.create(:email_campaign) }
+
+    it "should redirect to ActionPage#service_uri(service)" do
+      service, uri = "gmail", "https://composeurl.example.com"
+      expect(ActionPage).to receive(:find_by_id){ email_campaign.action_page }
+      expect(email_campaign).to receive(:service_uri).with(service){ uri }
+      get :email_target, { action_id: email_campaign.action_page.id, service: service }
+      expect(response).to redirect_to(uri)
+    end
+  end
 end
 
 def create_signature_and_have_user_sign

--- a/spec/factories/action_page.rb
+++ b/spec/factories/action_page.rb
@@ -26,4 +26,8 @@ FactoryGirl.define do
     association :active_action_page_for_redirect, :factory => :action_page
     victory false
   end
+
+  factory :action_page_with_email, :parent => :action_page do
+    enable_email true
+  end
 end

--- a/spec/factories/email_campaigns.rb
+++ b/spec/factories/email_campaigns.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :email_campaign do
+    after(:create) do |campaign|
+      FactoryGirl.create(:action_page_with_email, email_campaign_id: campaign.id)
+    end
+  end
+end

--- a/spec/factories/email_campaigns.rb
+++ b/spec/factories/email_campaigns.rb
@@ -1,5 +1,9 @@
 FactoryGirl.define do
   factory :email_campaign do
+    email_addresses "a@example.com, b@example.com"
+    subject "a subject"
+    message "a message"
+
     after(:create) do |campaign|
       FactoryGirl.create(:action_page_with_email, email_campaign_id: campaign.id)
     end

--- a/spec/models/email_campaign_spec.rb
+++ b/spec/models/email_campaign_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe EmailCampaign do
+  describe "#service_uri(service)" do
+    let(:campaign) do
+      FactoryGirl.create(:email_campaign, target_email: true, target_senate: false, target_house: false,
+                         email_addresses: "a@example.com, b@example.com",
+                         subject: "hey hey hey", message: "hello world")
+    end
+
+    context "service = :default" do
+      it "should redirect to a mailto uri" do
+        expect(campaign.service_uri(:default)).to eq("mailto:a@example.com,b@example.com?body=hello+world&subject=hey+hey+hey")
+      end
+    end
+
+    context "service = :gmail" do
+      it "should redirect to gmail's mail url" do
+        expect(campaign.service_uri(:gmail)).to eq("https://mail.google.com/mail/?view=cm&fs=1&to=a@example.com,b@example.com&body=hello+world&su=hey+hey+hey")
+      end
+    end
+
+    context "service = :hotmail" do
+      it "should redirect to outlook's mail url" do
+        expect(campaign.service_uri(:hotmail)).to eq("https://outlook.live.com/default.aspx?rru=compose&to=a@example.com,b@example.com&body=hello+world&subject=hey+hey+hey#page=Compose")
+      end
+    end
+  end
+end
+

--- a/spec/models/email_campaign_spec.rb
+++ b/spec/models/email_campaign_spec.rb
@@ -10,19 +10,19 @@ describe EmailCampaign do
 
     context "service = :default" do
       it "should redirect to a mailto uri" do
-        expect(campaign.service_uri(:default)).to eq("mailto:a@example.com,b@example.com?body=hello+world&subject=hey+hey+hey")
+        expect(campaign.service_uri(:default)).to eq("mailto:a@example.com,b@example.com?body=hello%20world&subject=hey%20hey%20hey")
       end
     end
 
     context "service = :gmail" do
       it "should redirect to gmail's mail url" do
-        expect(campaign.service_uri(:gmail)).to eq("https://mail.google.com/mail/?view=cm&fs=1&to=a@example.com,b@example.com&body=hello+world&su=hey+hey+hey")
+        expect(campaign.service_uri(:gmail)).to eq("https://mail.google.com/mail/?view=cm&fs=1&to=a@example.com,b@example.com&body=hello%20world&su=hey%20hey%20hey")
       end
     end
 
     context "service = :hotmail" do
       it "should redirect to outlook's mail url" do
-        expect(campaign.service_uri(:hotmail)).to eq("https://outlook.live.com/default.aspx?rru=compose&to=a@example.com,b@example.com&body=hello+world&subject=hey+hey+hey#page=Compose")
+        expect(campaign.service_uri(:hotmail)).to eq("https://outlook.live.com/default.aspx?rru=compose&to=a@example.com,b@example.com&body=hello%20world&subject=hey%20hey%20hey#page=Compose")
       end
     end
   end

--- a/spec/models/email_campaign_spec.rb
+++ b/spec/models/email_campaign_spec.rb
@@ -16,13 +16,13 @@ describe EmailCampaign do
 
     context "service = :gmail" do
       it "should redirect to gmail's mail url" do
-        expect(campaign.service_uri(:gmail)).to eq("https://mail.google.com/mail/?view=cm&fs=1&to=a@example.com,b@example.com&body=hello%20world&su=hey%20hey%20hey")
+        expect(campaign.service_uri(:gmail)).to eq("https://mail.google.com/mail/?view=cm&fs=1&to=a%40example.com%2C%20b%40example.com&body=hello%20world&su=hey%20hey%20hey")
       end
     end
 
     context "service = :hotmail" do
       it "should redirect to outlook's mail url" do
-        expect(campaign.service_uri(:hotmail)).to eq("https://outlook.live.com/default.aspx?rru=compose&to=a@example.com,b@example.com&body=hello%20world&subject=hey%20hey%20hey#page=Compose")
+        expect(campaign.service_uri(:hotmail)).to eq("https://outlook.live.com/default.aspx?rru=compose&to=a%40example.com%2C%20b%40example.com&body=hello%20world&subject=hey%20hey%20hey#page=Compose")
       end
     end
   end

--- a/spec/models/email_campaign_spec.rb
+++ b/spec/models/email_campaign_spec.rb
@@ -16,13 +16,13 @@ describe EmailCampaign do
 
     context "service = :gmail" do
       it "should redirect to gmail's mail url" do
-        expect(campaign.service_uri(:gmail)).to eq("https://mail.google.com/mail/?view=cm&fs=1&to=a%40example.com%2C%20b%40example.com&body=hello%20world&su=hey%20hey%20hey")
+        expect(campaign.service_uri(:gmail)).to eq("https://mail.google.com/mail/?view=cm&fs=1&body=hello+world&su=hey+hey+hey&to=a%40example.com%2C+b%40example.com")
       end
     end
 
     context "service = :hotmail" do
       it "should redirect to outlook's mail url" do
-        expect(campaign.service_uri(:hotmail)).to eq("https://outlook.live.com/default.aspx?rru=compose&to=a%40example.com%2C%20b%40example.com&body=hello%20world&subject=hey%20hey%20hey#page=Compose")
+        expect(campaign.service_uri(:hotmail)).to eq("https://outlook.live.com/default.aspx?rru=compose&body=hello+world&subject=hey+hey+hey&to=a%40example.com%2C+b%40example.com#page=Compose")
       end
     end
   end


### PR DESCRIPTION
This branch replaces escaping done by `CGI::escape` with `ERB::Utils#url_encode` (which is aliased as `u`), fixing #194. I created a `service_uri` method for email campaigns, which responds with a mailto or compose url for the given mail provider, and I've also updated the format for outlook urls, since the current links seem to no longer work.