### PR TITLE
Fix call tool for custom campaigns

### DIFF
--- a/app/assets/javascripts/application/tools/call.js
+++ b/app/assets/javascripts/application/tools/call.js
@@ -3,38 +3,13 @@ $(document).on('ready', function() {
     height_changed();
 
     var call_campaign_id = $('[data-call-campaign-id]').attr('data-call-campaign-id');
-    var url = '/tools/call_required_fields?call_campaign_id=' + call_campaign_id;
-    var required_location;
-
-    var $phone_number_field = $(document.getElementById('phone-input').text);
-    var $zip_field = $(document.getElementById('zip-input').text);
-    var $street_address_field = $(document.getElementById('street-address-input').text);
+    var $phone_number_field = $("#inputPhone");
+    var $zip_field = $("#inputZip");
+    var $street_address_field = $("#inputStreesAddress");
+    var required_location = !!$street_address_field.length;
 
     $phone_number_field.each(function(){
-      $phone = $(this);
-      $phone.bfhphone($phone.data());
-    });
-
-    $.ajax({
-      url: url,
-      success: function(res){
-        var $container = $('#call-tool-form-container');
-
-        required_location = res.userLocation;
-
-        $('.call-tool-submit').removeAttr('disabled');
-        $container.html("");
-        if(required_location == "postal"){
-          $container.append($phone_number_field);
-          $container.append($zip_field);
-        }
-        if(required_location == "latlon"){
-          $container.append($phone_number_field);
-          $container.append($street_address_field);
-          $container.append($zip_field);
-        }
-        height_changed();
-      }
+      $(this).bfhphone($(this).data());
     });
 
     function submit_call_request(phone, location, zip_code, street_address, action_id, call_campaign_id, update_user_data){
@@ -54,7 +29,7 @@ $(document).on('ready', function() {
     }
 
     function determine_location(cb, zip_code, street_address){
-      if(required_location == "latlon"){
+      if(required_location) {
         $.ajax({
           url: '/smarty_streets/street_address/?street=' + encodeURIComponent(street_address) + '&zipcode=' + encodeURIComponent(zip_code),
           success: function(res){
@@ -68,8 +43,8 @@ $(document).on('ready', function() {
             cb(err);
           }
         });
-      } else if (required_location == "postal") {
-        cb(null, zip_code)
+      } else {
+        cb(null, null);
       }
     }
 
@@ -94,13 +69,13 @@ $(document).on('ready', function() {
       var update_user_data = $('#update_user_data', form).val();
       var phone_number = $phone_number_field.val().replace(/[^\d.]/g, '');
       var street_address = $street_address_field.val();
-      var zip_code = $zip_field.val().replace(/[^\d.]/g, '').slice(0,5);
+      var zip_code = ($zip_field.val() || "").replace(/[^\d.]/g, '').slice(0,5);
       var action_id = $('[name="action-id"]', form).val();
 
-      if(!isValidPhoneNumber(phone_number)){
+      if (!isValidPhoneNumber(phone_number)){
         rumbleEl($phone_number_field);
-      } else if(zip_code.length != 5) {
-        rumbleEl($zip_code_field);
+      } else if ($zip_field.length && zip_code.length != 5) {
+        rumbleEl($zip_field);
       } else {
         determine_location(function(err, location){
           hide_form();

--- a/app/controllers/admin/action_pages_controller.rb
+++ b/app/controllers/admin/action_pages_controller.rb
@@ -1,4 +1,3 @@
-require 'quotes'
 class Admin::ActionPagesController < Admin::ApplicationController
   before_filter :set_action_page, except: [ :new, :index, :create, :update_featured_pages ]
   before_filter :set_date_from_params, only: [:index, :edit, :new]

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,4 +1,3 @@
-require 'quotes'
 class Admin::ApplicationController < ApplicationController
   layout 'admin'
   before_filter :must_be_admin

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -1,8 +1,6 @@
-require 'smarty_streets'
 require 'rest_client'
 require 'uri'
 require 'json'
-require 'call_tool'
 
 class ToolsController < ApplicationController
   before_filter :set_user

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -2,16 +2,14 @@ require 'smarty_streets'
 require 'rest_client'
 require 'uri'
 require 'json'
+require 'call_tool'
+
 class ToolsController < ApplicationController
   before_filter :set_user
   before_filter :set_action_page
   after_filter :deliver_thanks_message, only: [:call, :petition, :email]
   skip_after_filter :deliver_thanks_message, if: :signature_has_errors
   skip_before_filter :verify_authenticity_token, only: :petition
-
-  def call_required_fields
-    render :json => CallTool.required_fields_for_campaign(params[:call_campaign_id])
-  end
 
   def call
     ahoy.track "Action",

--- a/app/models/action_page.rb
+++ b/app/models/action_page.rb
@@ -1,5 +1,3 @@
-require 'amazon_credentials'
-
 class ActionPage < ActiveRecord::Base
   extend FriendlyId, AmazonCredentials
 

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -1,5 +1,4 @@
 require 'aws/s3'
-require './lib/amazon_credentials.rb'
 
 class SourceFile < ActiveRecord::Base
   include Rails.application.routes.url_helpers

--- a/app/views/tools/_call.html.erb
+++ b/app/views/tools/_call.html.erb
@@ -24,16 +24,13 @@
           <fieldset>
             <div class="form-group">
               <div id="call-tool-form-container">
+                <input type="text" required class="form-control bfh-phone" id="inputPhone" name="inputPhone" value="<%= current_user.try :phone -%>" data-format="ddd-ddd-dddd" pattern="^((5\d[123467890])|(5[123467890]\d)|([2346789]\d\d))-\d\d\d-\d\d\d\d$" placeholder="Phone Number" title="Must be a valid US phone number entered in 555-555-5555 format">
                 <% case CallTool.required_fields_for_campaign(@actionPage.call_campaign.call_campaign_id)["userLocation"] %>
                 <% when "postal" %>
-                  <input type="text" required class="form-control bfh-phone" id="inputPhone" name="inputPhone" value="<%= current_user.try :phone -%>" data-format="ddd-ddd-dddd" pattern="^((5\d[123467890])|(5[123467890]\d)|([2346789]\d\d))-\d\d\d-\d\d\d\d$" placeholder="Phone Number" title="Must be a valid US phone number entered in 555-555-5555 format">
                   <input type="text" required class="form-control" id="inputZip" name="inputZip" value="<%= current_user.try :zipcode -%>" placeholder="Zip Code" pattern='^[\d]{5}$' title='Must be a valid 5-digit zip code'>
                 <% when "latlon" %>
-                  <input type="text" required class="form-control bfh-phone" id="inputPhone" name="inputPhone" value="<%= current_user.try :phone -%>" data-format="ddd-ddd-dddd" pattern="^((5\d[123467890])|(5[123467890]\d)|([2346789]\d\d))-\d\d\d-\d\d\d\d$" placeholder="Phone Number" title="Must be a valid US phone number entered in 555-555-5555 format">
                   <input type="text" required class="form-control" id="inputStreetAddress" name="inputStreetAddress" value="<%= current_user.try :street_address -%>" placeholder="Street Address" title='Must be a valid US street address (no city or state necessary)'>
                   <input type="text" required class="form-control" id="inputZip" name="inputZip" value="<%= current_user.try :zipcode -%>" placeholder="Zip Code" pattern='^[\d]{5}$' title='Must be a valid 5-digit zip code'>
-                <% else %>
-                  <input type="text" required class="form-control bfh-phone" id="inputPhone" name="inputPhone" value="<%= current_user.try :phone -%>" data-format="ddd-ddd-dddd" pattern="^((5\d[123467890])|(5[123467890]\d)|([2346789]\d\d))-\d\d\d-\d\d\d\d$" placeholder="Phone Number" title="Must be a valid US phone number entered in 555-555-5555 format">
                 <% end %>
               </div>
             </div>

--- a/app/views/tools/_call.html.erb
+++ b/app/views/tools/_call.html.erb
@@ -1,12 +1,3 @@
-<script type='text/x-underscore-template' id='zip-input'>
-  <input type="text" required class="form-control" id="inputZip" name="inputZip" value="<%= current_user.try :zipcode -%>" placeholder="Zip Code" pattern='^[\d]{5}$' title='Must be a valid 5-digit zip code'>
-</script>
-<script type='text/x-underscore-template' id='street-address-input'>
-  <input type="text" required class="form-control" id="inputStreetAddress" name="inputStreetAddress" value="<%= current_user.try :street_address -%>" placeholder="Street Address" title='Must be a valid US street address (no city or state necessary)'>
-</script>
-<script type='text/x-underscore-template' id='phone-input'>
-  <input type="text" required class="form-control bfh-phone" id="inputPhone" name="inputPhone" value="<%= current_user.try :phone -%>" data-format="ddd-ddd-dddd" pattern="^((5\d[123467890])|(5[123467890]\d)|([2346789]\d\d))-\d\d\d-\d\d\d\d$" placeholder="Phone Number" title="Must be a valid US phone number entered in 555-555-5555 format">
-</script>
 <div id='call-tool' class="tool">
   <div class="tool-container">
     <div class="tool-heading">
@@ -32,13 +23,23 @@
           <input type="hidden" name="action-id" value="<%= @actionPage.id %>" />
           <fieldset>
             <div class="form-group">
-              <div id='call-tool-form-container'>
-                Loading...
+              <div id="call-tool-form-container">
+                <% case CallTool.required_fields_for_campaign(@actionPage.call_campaign.call_campaign_id)["userLocation"] %>
+                <% when "postal" %>
+                  <input type="text" required class="form-control bfh-phone" id="inputPhone" name="inputPhone" value="<%= current_user.try :phone -%>" data-format="ddd-ddd-dddd" pattern="^((5\d[123467890])|(5[123467890]\d)|([2346789]\d\d))-\d\d\d-\d\d\d\d$" placeholder="Phone Number" title="Must be a valid US phone number entered in 555-555-5555 format">
+                  <input type="text" required class="form-control" id="inputZip" name="inputZip" value="<%= current_user.try :zipcode -%>" placeholder="Zip Code" pattern='^[\d]{5}$' title='Must be a valid 5-digit zip code'>
+                <% when "latlon" %>
+                  <input type="text" required class="form-control bfh-phone" id="inputPhone" name="inputPhone" value="<%= current_user.try :phone -%>" data-format="ddd-ddd-dddd" pattern="^((5\d[123467890])|(5[123467890]\d)|([2346789]\d\d))-\d\d\d-\d\d\d\d$" placeholder="Phone Number" title="Must be a valid US phone number entered in 555-555-5555 format">
+                  <input type="text" required class="form-control" id="inputStreetAddress" name="inputStreetAddress" value="<%= current_user.try :street_address -%>" placeholder="Street Address" title='Must be a valid US street address (no city or state necessary)'>
+                  <input type="text" required class="form-control" id="inputZip" name="inputZip" value="<%= current_user.try :zipcode -%>" placeholder="Zip Code" pattern='^[\d]{5}$' title='Must be a valid 5-digit zip code'>
+                <% else %>
+                  <input type="text" required class="form-control bfh-phone" id="inputPhone" name="inputPhone" value="<%= current_user.try :phone -%>" data-format="ddd-ddd-dddd" pattern="^((5\d[123467890])|(5[123467890]\d)|([2346789]\d\d))-\d\d\d-\d\d\d\d$" placeholder="Phone Number" title="Must be a valid US phone number entered in 555-555-5555 format">
+                <% end %>
               </div>
             </div>
             <%= render 'tools/save_my_info_option', info: ['phone number', 'location'] -%>
             <div class="form-group">
-                <button type="submit" class="btn btn-default call-tool-submit" disabled>Call Now</button>
+                <button type="submit" class="btn btn-default call-tool-submit">Call Now</button>
             </div>
           </fieldset>
             <p class="privacy-notice">Uses <a href="http://sunlightfoundation.com/legal/privacy/" target="_blank">Sunlight Labs</a> and <a href="https://www.twilio.com/legal/privacy" target="_blank">Twilio</a>'s APIs (<a class="privacy-notice-popover" href="#"

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,8 @@ module Actioncenter
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    config.autoload_paths += %W(#{config.root}/lib)
+
     #config.logger = ActiveSupport::Logger.new(STDOUT)
     config.to_prepare do
           Devise::Mailer.layout "email" # email.haml or email.erb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ Actioncenter::Application.routes.draw do
   post "tools/petition"
   post "tools/tweet"
   post "tools/email"
-  get "tools/call_required_fields"
   get "tools/email_target"
   get "tools/reps"
   get "tools/reps_raw"

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -353,6 +353,55 @@ Given(/^my test env has Internet access and I have an S(\d+) key$/) do |arg1|
   pending if this_machine_offline? or ENV['amazon_access_key_id'].nil?
 end
 
+Given(/^a call petition targeting senate exists$/) do
+  setup_action
+  @call_campaign = FactoryGirl.create(:call_campaign, call_campaign_id: 1, message: "hey hey")
+  @action_page = @call_campaign.action_page
+  @action_page.update_attributes(title: @action_info[:title],
+    summary: @action_info[:summary],
+    description: @action_info[:description])
+
+  allow(CallTool).to receive(:required_fields_for_campaign){ { "userLocation" => "postal" } }
+  allow(CallTool).to receive(:campaign_call)
+end
+
+Given(/^a call petition targeting a custom number exists$/) do
+  setup_action
+  @call_campaign = FactoryGirl.create(:call_campaign, call_campaign_id: 1, message: "hey hey")
+  @action_page = @call_campaign.action_page
+  @action_page.update_attributes(title: @action_info[:title],
+    summary: @action_info[:summary],
+    description: @action_info[:description])
+
+  # custom campaigns are distinguished by having no "userLocation" in the call tool response
+  allow(CallTool).to receive(:required_fields_for_campaign){ { } }
+  allow(CallTool).to receive(:campaign_call)
+end
+
+Then(/^I see form fields for phone number and zip code$/) do
+  expect(page).to have_selector("input[name=inputPhone]")
+  expect(page).to have_selector("input[name=inputZip]")
+end
+
+Then(/^I see form fields for phone number but not zip code$/) do
+  expect(page).to have_selector("input[name=inputPhone]")
+  expect(page).not_to have_selector("input[name=inputZip]")
+end
+
+When(/^I fill in my phone number and zip code and click call$/) do
+  find("input[name=inputPhone]").set("415-555-0100")
+  find("input[name=inputZip]").set("94109")
+  find("button.call-tool-submit").click
+end
+
+When(/^I fill in my phone number and click call$/) do
+  find("input[name=inputPhone]").set("415-555-0100")
+  find("button.call-tool-submit").click
+end
+
+Then(/^I see instructions for what to say$/) do
+  expect(page).to have_selector(".call-body-active", visible: true)
+end
 
 def this_machine_offline?
   return $OfflineMode unless $OfflineMode.nil?

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -355,27 +355,20 @@ end
 
 Given(/^a call petition targeting senate exists$/) do
   setup_action
-  @call_campaign = FactoryGirl.create(:call_campaign, call_campaign_id: 1, message: "hey hey")
+  @call_campaign = FactoryGirl.create(:call_campaign, call_campaign_id: senate_call_campaign_id, message: "hey hey")
   @action_page = @call_campaign.action_page
   @action_page.update_attributes(title: @action_info[:title],
     summary: @action_info[:summary],
     description: @action_info[:description])
-
-  allow(CallTool).to receive(:required_fields_for_campaign){ { "userLocation" => "postal" } }
-  allow(CallTool).to receive(:campaign_call)
 end
 
 Given(/^a call petition targeting a custom number exists$/) do
   setup_action
-  @call_campaign = FactoryGirl.create(:call_campaign, call_campaign_id: 1, message: "hey hey")
+  @call_campaign = FactoryGirl.create(:call_campaign, call_campaign_id: custom_call_campaign_id, message: "hey hey")
   @action_page = @call_campaign.action_page
   @action_page.update_attributes(title: @action_info[:title],
     summary: @action_info[:summary],
     description: @action_info[:description])
-
-  # custom campaigns are distinguished by having no "userLocation" in the call tool response
-  allow(CallTool).to receive(:required_fields_for_campaign){ { } }
-  allow(CallTool).to receive(:campaign_call)
 end
 
 Then(/^I see form fields for phone number and zip code$/) do

--- a/features/support/call_tool_mock.rb
+++ b/features/support/call_tool_mock.rb
@@ -1,3 +1,6 @@
+
+require "call_tool"
+
 def senate_call_campaign_id; 1; end
 def custom_call_campaign_id; 2; end
 

--- a/features/support/call_tool_mock.rb
+++ b/features/support/call_tool_mock.rb
@@ -1,0 +1,18 @@
+def senate_call_campaign_id; 1; end
+def custom_call_campaign_id; 2; end
+
+module CallTool
+  def self.required_fields_for_campaign(campaign_id)
+    case campaign_id.to_i
+    when senate_call_campaign_id
+      { "userLocation" => "postal" }
+
+    when custom_call_campaign_id
+      { }
+    end
+  end
+
+  def self.campaign_call(*args)
+    warn "mock: campaign_call"
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,6 +7,8 @@
 require 'cucumber/rails'
 require 'cucumber/rspec/doubles'
 
+require_relative './call_tool_mock'
+
 Capybara.javascript_driver = :webkit
 
 Capybara::Webkit.configure do |config|

--- a/features/users/call_action.feature
+++ b/features/users/call_action.feature
@@ -1,0 +1,25 @@
+@javascript
+Feature: Do a Call Action
+  An interested member of the community should be able to call
+  Relevant congress members' offices
+
+  Background:
+    I am not logged in
+
+  Scenario: An activist creates a call petition and a supporter uses it
+    Given a call petition targeting senate exists
+
+    When I browse to the action page
+    Then I see form fields for phone number and zip code
+
+    When I fill in my phone number and zip code and click call
+    Then I see instructions for what to say
+
+  Scenario: An activist creates a call petition for a custom target and a supporter uses it
+    Given a call petition targeting a custom number exists
+
+    When I browse to the action page
+    Then I see form fields for phone number but not zip code
+
+    When I fill in my phone number and click call
+    Then I see instructions for what to say

--- a/features/users/call_action.feature
+++ b/features/users/call_action.feature
@@ -14,12 +14,3 @@ Feature: Do a Call Action
 
     When I fill in my phone number and zip code and click call
     Then I see instructions for what to say
-
-  Scenario: An activist creates a call petition for a custom target and a supporter uses it
-    Given a call petition targeting a custom number exists
-
-    When I browse to the action page
-    Then I see form fields for phone number but not zip code
-
-    When I fill in my phone number and click call
-    Then I see instructions for what to say

--- a/features/users/call_action_custom_target.feature
+++ b/features/users/call_action_custom_target.feature
@@ -1,0 +1,15 @@
+@javascript
+Feature: Do a Call Action
+  An interested member of the community should be able to call a custom campaign target
+
+  Background:
+    I am not logged in
+
+  Scenario: An activist creates a call petition for a custom target and a supporter uses it
+    Given a call petition targeting a custom number exists
+
+    When I browse to the action page
+    Then I see form fields for phone number but not zip code
+
+    When I fill in my phone number and click call
+    Then I see instructions for what to say

--- a/lib/tasks/signatures.rake
+++ b/lib/tasks/signatures.rake
@@ -1,4 +1,3 @@
-require 'smarty_streets'
 namespace :signatures do
   desc "Fill in US States from zipcodes"
   task :fill_us_states => :environment do

--- a/spec/controllers/tools_controller_spec.rb
+++ b/spec/controllers/tools_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'call_tool'
 
 RSpec.describe ToolsController, type: :controller do
 

--- a/spec/factories/call_campaigns.rb
+++ b/spec/factories/call_campaigns.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory :call_campaign do
+    title "a call campaign"
+
     after(:create) do |campaign|
       FactoryGirl.create(:action_page_with_call, call_campaign_id: campaign.id)
     end

--- a/spec/lib/call_tool_spec.rb
+++ b/spec/lib/call_tool_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require "call_tool"
 
 describe CallTool do
   describe ".campaign_call" do


### PR DESCRIPTION
Call actions currently break when the campaign is configured as "custom" on call.eff.org. In that case the tool doesn't require any location data, and as a result action center doesn't append any inputs to the call form (even for phone number)

[call.js](https://github.com/EFForg/action-center-platform/blob/master/app/assets/javascripts/application/tools/call.js#L27-L35)
```javascript
        if(required_location == "postal"){
          $container.append($phone_number_field);
          $container.append($zip_field);
        }
        if(required_location == "latlon"){
          $container.append($phone_number_field);
          $container.append($street_address_field);
          $container.append($zip_field);
        }
        // ... no catch for required_location == undefined
```

This branch fixes the bug. I no longer ask for the campaign's required fields in an ajax request, and instead just create the corresponding form elements on the initial page serve. When the call campaign is custom, only a phone number input is required.