### PR TITLE
Create rake task for deleting petition signatures with non-unique email

### DIFF
--- a/lib/tasks/signatures.rake
+++ b/lib/tasks/signatures.rake
@@ -17,4 +17,13 @@ namespace :signatures do
       end
     end
   end
+
+  desc "Deduplicate signatures (identified by email) from petitions"
+  task deduplicate: :environment do
+    dups = Signature.group(:petition_id, :email).having("count(*) > 1")
+    dups.pluck(:petition_id, :email).each do |petition_id, email|
+      ids = Signature.where(petition_id: petition_id, email: email).order(:created_at).ids
+      Signature.where(id: ids[1..-1]).delete_all
+    end
+  end
 end

--- a/spec/tasks/signatures_spec.rb
+++ b/spec/tasks/signatures_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require "rake"
+
+describe "signatures namespace rake tasks" do
+  before do
+    Rake.application.rake_require("tasks/signatures")
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "signatures:deduplicate" do
+    it "should delete signatures with non-unique emails from petitions" do
+      regular_petition = FactoryGirl.create(:petition_complete_with_one_hundred_signatures)
+
+      petition_with_dups = FactoryGirl.create(:petition_complete_with_one_hundred_signatures)
+      petition_with_dups.signatures.take(20).each{ |sig| sig.update_column(:email, "dup1@example.com") }
+      petition_with_dups.signatures.take(10).each{ |sig| sig.update_column(:email, "dup2@example.com") }
+
+      distinct_emails = petition_with_dups.signatures.pluck(:email).uniq
+
+      expect(regular_petition.signatures.select("email").distinct.count).to eq(100)
+      expect(petition_with_dups.signatures.select("email").distinct.count).to eq(82)
+
+      Rake.application.invoke_task "signatures:deduplicate"
+
+      # Check that regular petition was unaffected and that the other contains no duplicates
+      expect(regular_petition.signatures.reload.count).to eq(100)
+      expect(petition_with_dups.signatures.reload.count).to eq(82)
+      expect(petition_with_dups.signatures.reload.pluck(:email)).to contain_exactly(*distinct_emails)
+    end
+  end
+end


### PR DESCRIPTION
This branch implements the idea suggested in #3 -- that there should be a rake task for deleting duplicate signatures.