### PR TITLE
Remove extra newline so dnt hashes correctly

### DIFF
--- a/public/.well-known/dnt-policy.txt
+++ b/public/.well-known/dnt-policy.txt
@@ -216,4 +216,3 @@ those domains pertain to specific topics or activities, but records of visited
 DNS names are not reading habits if those domain names serve content of a very
 diverse and general nature, thereby revealing minimal information about the
 opinions, interests or activities of the user.
-


### PR DESCRIPTION
Cooper says:

our copy of the DNT policy on act.eff.org does not hash correctly, which
means privacy badger won't recognize it. I suspect that this is due to
an extra newline character at the end of it. The one on
eff.org/.well-known/dnt-policy.txt is correct.