### PR TITLE
Use different source for phantomjs binary download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 RUN ln -s /phantomjs-2.1.1-linux-x86_64/bin/phantomjs /bin/phantomjs
 
 # Set up phantomjs, making sure to check the known good sha256sum
-RUN cd / && curl -sLo phantomjs.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
+RUN cd / && curl -sLo phantomjs.tar.bz2 https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
   bash -l -c '[ "`sha256sum phantomjs.tar.bz2 | cut -f1 -d" "`" = "86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f" ]' && \
   tar -jxvf phantomjs.tar.bz2 > /dev/null && \
   rm phantomjs.tar.bz2


### PR DESCRIPTION
This branch fixes #215. This is a common issue apparently, tracked at https://github.com/ariya/phantomjs/issues/13953. Bitbucket rate limits their downloads so lots of folks get errors fetching phantomjs in their ci builds.

There is a a github mirror of the binaries at https://github.com/Medium/phantomjs/releases/tag/v2.1.1. I change our Dockerfile to fetch from it (note that the sha256 sum is identical).