### PR TITLE
Resize the window when the sidebar grows.

### DIFF
--- a/app/assets/javascripts/application/height_changed.js
+++ b/app/assets/javascripts/application/height_changed.js
@@ -1,5 +1,9 @@
 var height_changed = function(){
+  // If using scroll effect, adjust the window height so the sidebar fits.
+  if (window.scroller) window.scroller();
+
+  // For embeds, notify the parent window so it can resize the iframe.
   var container = document.querySelector("div.container");
   var height = Math.max( container.scrollHeight, container.offsetHeight );
-  window.parent.postMessage(height, "*"); 
+  window.parent.postMessage(height, "*");
 }

--- a/app/assets/javascripts/application/sticky_tools.js
+++ b/app/assets/javascripts/application/sticky_tools.js
@@ -43,7 +43,7 @@ $(function() {
     }
 
     window.scroller = scroller;
-    window.scroller = resizer;
+    window.resizer = resizer;
 
     if (window.addEventListener) {
       window.addEventListener('scroll', scroller, false);


### PR DESCRIPTION
Fixes #125.

Previously, when an action had a very short body and description, and users submitted their address in order to contact congress, the window would not grow large enough to show all the content inserted into the sidebar.

This pull request fixes that issue by triggering a resize when the content is inserted.