### PR TITLE
Serialize updated_at timestamp more precisely

### DIFF
--- a/app/views/admin/action_pages/_form.html.erb
+++ b/app/views/admin/action_pages/_form.html.erb
@@ -26,7 +26,9 @@
 
   <input id='anchor' type=hidden name=anchor>
   <% unless @actionPage.new_record? -%>
-  <%= f.hidden_field :updated_at, data: {url: admin_action_page_updated_at_path(@actionPage) }-%>
+  <%= f.hidden_field :updated_at,
+      value: f.object.updated_at.strftime("%Y/%m/%d %H:%M:%S.%9N %Z %z"),
+      data: { url: admin_action_page_updated_at_path(@actionPage) } -%>
   <% end -%>
 <% end -%>
 

--- a/spec/controllers/admin/action_pages_controller_spec.rb
+++ b/spec/controllers/admin/action_pages_controller_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Admin::ActionPagesController, type: :controller do
+  include Devise::TestHelpers
+
+  before(:each) do
+    @request.env["devise.mapping"] = Devise.mappings[:admin]
+    sign_in FactoryGirl.create(:admin_user)
+  end
+
+  let(:petition_action_page){ FactoryGirl.create(:action_page_with_petition) }
+
+  describe "GET #updated_at" do
+    def tparam(time)
+      time.strftime("%Y/%m/%d %H:%M:%S.%9N %Z %z")
+    end
+
+    it ".updated field should be false if params[:updated_at] is gte action_page.updated_at" do
+      get :updated_at, { action_page_id: petition_action_page.to_param,
+                         updated_at: tparam(petition_action_page.updated_at) }
+
+      expect(response.content_type).to eq("application/json")
+      expect(JSON.parse(response.body)["updated"]).to eq(false)
+
+      get :updated_at, { action_page_id: petition_action_page.to_param,
+                         updated_at: tparam(petition_action_page.updated_at + 2) }
+
+      expect(response.content_type).to eq("application/json")
+      expect(JSON.parse(response.body)["updated"]).to eq(false)
+    end
+
+    it ".updated field should be true if params[:updated_at] is lt action_page.updated_at" do
+      get :updated_at, { action_page_id: petition_action_page.to_param,
+                         updated_at: tparam(petition_action_page.updated_at - 0.1) }
+
+      expect(response.content_type).to eq("application/json")
+      expect(JSON.parse(response.body)["updated"]).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
This branch fixes #220. When a timestamp is used for a field value, `#to_s` is called which truncates the fractional seconds part. If the value is later parsed and compared against the original time it will appear to be in the past. This branch ensures the field value includes the fractional seconds part.