### PR TITLE
CSS cleanup

### DIFF
--- a/app/assets/stylesheets/action_page.css.scss
+++ b/app/assets/stylesheets/action_page.css.scss
@@ -57,9 +57,9 @@
 }
 
 .form-control {
-    border-radius: 0;
-    padding: 0 0.5em;
-    font-size: 0.8em;
+  border-radius: 0;
+  padding: 0 0.5em;
+  font-size: 0.8em;
 }
 
 #share-buttons-wrapper {
@@ -141,10 +141,6 @@
     }
     .input-pair {
       margin-bottom: 0.5em;
-    }
-    .form-group > input[type=text], .form-group > input[type=email], .form-group > input[type=tel]  {
-      font-size: 1em;
-      height: 40px;
     }
     input[type=submit], button[type=submit] {
       @include speak-out-button

--- a/app/assets/stylesheets/admin/_edit.css.scss
+++ b/app/assets/stylesheets/admin/_edit.css.scss
@@ -56,12 +56,14 @@ Main Form
     resize: vertical;
   }
 
-  input[type=text], textarea {
+  input[type=text], textarea, select {
     display: block;
     width: 100%;
     padding: 0.25em 0.5em;
     border: 1px solid #cce;
     border-radius: 4px;
+    font-size: 1em;
+    background-color: #fff;
   }
 
   input[type=submit] {
@@ -71,6 +73,7 @@ Main Form
   fieldset {
     padding: 0 1em 0.5em;
   }
+
 }
 
 
@@ -258,7 +261,7 @@ File upload/gallery
 }
 
 .fileupload-buttonbar {
-  margin-bottom: 20px; 
+  margin-bottom: 20px;
 }
 
 // Fix Gallery button position on non-mobile devices

--- a/app/assets/stylesheets/application/_base.css.scss
+++ b/app/assets/stylesheets/application/_base.css.scss
@@ -255,6 +255,10 @@ a:hover {
   margin-bottom: 20px;
 }
 
+.panel-body {
+  color: $darkgrey;
+}
+
 /* ==============================================
 Styles for the alert box
 ===============================================*/

--- a/app/assets/stylesheets/application/_base.css.scss
+++ b/app/assets/stylesheets/application/_base.css.scss
@@ -25,7 +25,7 @@ body>.wrapper {
 }
 
 .checkbox.small {
-  line-height: 1.1;
+  color: $darkgrey;
 }
 
 .radio label, .checkbox label {

--- a/app/views/admin/action_pages/_panel_settings.html.erb
+++ b/app/views/admin/action_pages/_panel_settings.html.erb
@@ -54,8 +54,7 @@
             </div>
             <div class="form-group">
               <%= f.label :partner_id, 'Partner newsletter' -%>
-              <%= f.collection_select :partner_id, Partner.all, :id, :name,
-                {include_blank: 'None'}, {class: 'form-control'} -%>
+              <%= f.collection_select :partner_id, Partner.all, :id, :name, include_blank: 'None' -%>
               <p class='hint-text small'><%= link_to 'Add or edit partners', admin_partners_path, target: :blank -%></p>
             </div>
             <div class="form-group">

--- a/app/views/admin/action_pages/_panel_victory.html.erb
+++ b/app/views/admin/action_pages/_panel_victory.html.erb
@@ -30,7 +30,7 @@
         <div id='archived-fields' class='panel-body collapse <%= 'in' if @actionPage.archived? -%>'>
           <div class="form-group">
             <%= f.label :archived_redirect_action_page_id do -%>Redirect:<% end %>
-            <%= collection_select :action_page, :archived_redirect_action_page_id, ActionPage.all.where.not(id: @actionPage.id), :id, :title, {:include_blank => "  Disabled", :object => @actionPage}, {:class => 'form-control'} %>
+            <%= collection_select :action_page, :archived_redirect_action_page_id, ActionPage.all.where.not(id: @actionPage.id), :id, :title, {:include_blank => "  Disabled", :object => @actionPage} %>
           </div>
         </div><!-- #archived-fields -->
 

--- a/app/views/tools/_email.html.erb
+++ b/app/views/tools/_email.html.erb
@@ -136,7 +136,7 @@
 <div class="update-user-data-container" style="display: none;">
   <% if current_user %>
   <div class="checkbox small">
-      <label class="small" for="update_user_data">    <input checked="checked" id="update_user_data" name="update_user_data" type="checkbox" value="yes">    Save my name and address for next time.</label>
+      <label for="update_user_data">    <input checked="checked" id="update_user_data" name="update_user_data" type="checkbox" value="yes">    Save my name and address for next time.</label>
   </div>
   <% end %>
 </div>

--- a/app/views/tools/_petition.html.erb
+++ b/app/views/tools/_petition.html.erb
@@ -111,7 +111,7 @@
             <fieldset>
               <% unless @petition.enable_affiliations %>
                 <div class='checkbox small'>
-                  <%= f.label :anonymous, class: :small do -%>
+                  <%= f.label :anonymous do -%>
                     <%= check_box_tag 'signature[anonymous]' -%>
                     <%= t :dont_show_my_name -%>
                   <% end -%>

--- a/app/views/tools/_save_my_info_option.html.erb
+++ b/app/views/tools/_save_my_info_option.html.erb
@@ -1,6 +1,6 @@
 <% if user_signed_in? -%>
   <div class='checkbox small'>
-    <%= label_tag :update_user_data, class: :small do -%>
+    <%= label_tag :update_user_data do -%>
       <%= check_box_tag :update_user_data, 'yes', checked=user_signed_in? -%>
       <%= t :save_my_info, info: info.to_sentence -%>
     <% end -%>


### PR DESCRIPTION
- Fixes #198
- Increases the size of small checkboxes on actions (they were getting the 'small' class twice for .7x.7 size). I changed the color to dark grey to preserve some extra small feel.
- Removed the need for .form-control on action page edit selects. This is a little weird since we're using the .form-control class provided by bootstrap for the action pages themselves but mostly not using it for the admin pages....but at least it's consistent with the current system.