### PR TITLE
Fix infinite loop on password reset

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,9 @@ class User < ActiveRecord::Base
   validate :password_complexity
   delegate :actions, :views, to: :events
 
-  before_update :invalidate_password_reset_tokens, :if => proc { email_changed? }
-  before_update :invalidate_new_activists_password, :if => proc { admin_changed?  }
-  after_update :reset_password_expiration_flag, :if => proc { encrypted_password_changed? && !password_expired_changed? }
+  before_update :invalidate_password_reset_tokens, :if => :email_changed?
+  before_update :invalidate_new_activists_password, :if => :admin_changed?
+  after_validation :reset_password_expiration_flag, :if => :encrypted_password_changed?
 
   alias :preferences :user_preferences
 
@@ -30,7 +30,6 @@ class User < ActiveRecord::Base
 
   def reset_password_expiration_flag
     self.password_expired = false
-    self.save
   end
 
   def email_taken?

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -478,3 +478,9 @@ Then(/^the email "(.*?)" should not go to "(.*?)"$/) do |subject, address|
     email.subject.should not_include subject if email.to == address
   end
 end
+
+And(/^I follow the password reset link$/) do
+  email = ActionMailer::Base.deliveries.first
+  reset_link = URI.extract(email.text_part.to_s)[2]
+  visit reset_link
+end

--- a/features/users/reset_password.feature
+++ b/features/users/reset_password.feature
@@ -1,0 +1,14 @@
+Feature: A user can reset their password
+
+  Background:
+    Given a user with the email "me@example.com"
+
+  Scenario: A user resets their password
+    When I go to "/password/new"
+    And I fill in "Email" with "me@example.com"
+    And I press "Send me reset password instructions"
+    And I follow the password reset link
+    And I fill in "user_password" with "a strong enough password"
+    And I fill in "user_password_confirmation" with "a strong enough password"
+    And I press "Change my password"
+    Then I should see "Your password was changed! You are now signed in."

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,6 +31,17 @@ describe User do
       result = set_strong_password(user)
       expect(result).to be_truthy
     end
+
+    it "allows users to reset their password when password_expired = false" do
+      user = FactoryGirl.create(:user, password_expired: false)
+      expect(set_strong_password(user)).to be_truthy
+    end
+
+    it "resets the password_expired flag when password changes" do
+      user = FactoryGirl.create(:user, password_expired: true)
+      set_strong_password(user)
+      expect(user.password_expired).to be_falsey
+    end
   end
 
   describe "track user actions" do


### PR DESCRIPTION
When user.password_expired was set to false (rather than true or nil), resetting the password would result in an infinite loop. 

This commit fixes that bug and preserves the behavior where resetting a password sets password_expired to false.

Resolves 11301 in Redmine (both Starchy and the submitter have password_expired=false, while most users have password_expired=nil)