### PR TITLE
Don't error if user doesn't exist. Fixes #251.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,15 +19,14 @@ class SessionsController < Devise::SessionsController
   end
 
   def create
-    u = User.find_by_email(params[:user][:email])
-    if u.valid_password?(params[:user][:password]) && u.password_expired?
-      # thrust the user to a change password page....
-      # Create a reset token
-      # redirect to the reset page token... which can't be done because that
-      # only goes through the mail...
-      redirect_to '/sessions/password_reset'
-    else
-      super
+    super do
+      if current_user.password_expired?
+        # thrust the user to a change password page....
+        # Create a reset token
+        # redirect to the reset page token... which can't be done because that
+        # only goes through the mail...
+        redirect_to "/sessions/password_reset"
+      end
     end
   end
 


### PR DESCRIPTION
Devise gives us another handy yield from super to do what we want here. Fixes a nil error that happens when the user doesn't exist.