### PR TITLE
Nonroot docker user

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,4 +24,6 @@ export HOST_IP=`/sbin/ip route|awk '/default/ { print $3 }'`
 
 printenv | sed 's/^\([[:alnum:]_]*\)=\(.*\)$/export \1="\2"/' >/root/.profile
 
+chmod o+w /usr/local/bundle/config
+
 exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 rm -rf tmp/
+mkdir tmp
 
 if [ "$DB_AUTO_MIGRATE" == "true" ]; then
   bin/rake db:migrate


### PR DESCRIPTION
This allows us to run the app as a non-root user (fixes #208) by using something like this in docker-compose.yml:

```yaml
command: sh -c 'chown www-data log tmp && su www-data -s/bin/bash -c "bundle exec unicorn"'
```