### PR TITLE
Do ahoy visit tracking via image tag embedded in page

### DIFF
--- a/app/controllers/action_page_controller.rb
+++ b/app/controllers/action_page_controller.rb
@@ -139,17 +139,6 @@ private
                               country_code: current_country_code,
                               email: current_email }
 
-    # Tracking
-    if params[:action] == "show"
-      @action_type = "view"
-    else
-      @action_type = "embedded_view"
-    end
-
-    ahoy.track "View",
-      { type: "action", actionType: @action_type, actionPageId: @actionPage.id },
-      action_page: @actionPage
-
     #request.session_options[:skip] = true  # removes session data
     #response.headers.delete 'Set-Cookie'
     response.headers['Cache-Control'] = 'public, no-cache'

--- a/app/controllers/ahoy_controller.rb
+++ b/app/controllers/ahoy_controller.rb
@@ -1,0 +1,23 @@
+class AhoyController < ApplicationController
+  before_action :set_ahoy_cookies
+  before_action :track_ahoy_visit
+  before_action :set_ahoy_request_store
+
+  def visit
+    action_type = params.require(:action_type)
+    action_page_id = params.require(:action_page_id)
+
+    ahoy.track "View",
+      { type: "action", actionType: action_type, actionPageId: action_page_id },
+      action_page_id: action_page_id
+
+    send_data image_asset, content_type: "image/gif"
+  end
+
+  private
+
+  def image_asset
+    # app/assets/images/empty.gif
+    "GIF89a\u0001\u0000\u0001\u0000\x80\u0000\u0000\xFF\xFF\xFF\u0000\u0000\u0000!\xF9\u0004\u0001\u0000\u0000\u0000\u0000,\u0000\u0000\u0000\u0000\u0001\u0000\u0001\u0000\u0000\u0002\u0002D\u0001\u0000;"
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,10 @@ class ApplicationController < ActionController::Base
   before_filter :user_conditional_logic
   after_filter :set_cache_headers
 
+  skip_before_action :set_ahoy_cookies
+  skip_before_action :track_ahoy_visit
+  skip_before_action :set_ahoy_request_store
+
   def user_conditional_logic
     if user_signed_in?
       lock_users_with_expired_passwords! unless user_is_being_told_to_reset_pass_or_is_resetting_pass?

--- a/app/helpers/ahoy_helper.rb
+++ b/app/helpers/ahoy_helper.rb
@@ -1,0 +1,8 @@
+module AhoyHelper
+  def ahoy_track_tag(action_type, action_page_id)
+    content_tag(:div, style: "height: 0; overflow: hidden") {
+      params = { action_type: action_type, action_page_id: action_page_id, format: :gif }
+      image_tag(ahoy_visit_url(params), style: "border: 0", alt: "")
+    }
+  end
+end

--- a/app/views/action_page/embed_iframe.html.erb
+++ b/app/views/action_page/embed_iframe.html.erb
@@ -10,3 +10,4 @@
   <% end %>
 <% end -%>
 <%= render "tools/container" %>
+<%= ahoy_track_tag("embedded_view", @actionPage.id) %>

--- a/app/views/action_page/show.html.erb
+++ b/app/views/action_page/show.html.erb
@@ -37,3 +37,5 @@
 
   </div>
 </div>
+
+<%= ahoy_track_tag("show", @actionPage.id) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Actioncenter::Application.routes.draw do
   get "petition/:id/recent_signatures", :to => "petition#recent_signatures", :format => 'json'
   post "bounce/:amazon_authorize_key", :to => "bounce#index", :format => 'json'
 
+  get "ahoy/visit"
+
   # EFF Resources
 
   devise_for :users, path: '', path_names:  {sign_in:  'login',


### PR DESCRIPTION
Our action view tracking is currently problematic since those pages are cached behind a proxy. In this branch I instead create the ahoy event out of an embedded image on the action page. We can cache the action page and configure the proxy to always pass /ahoy/visit.gif through to the app.