### PR TITLE
Allow embedding form authenticity tokens in <esi:include> tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,10 @@ cors_allowed_domains=https://example.org https://some.example.com
 # Error reporting (not required)
 sentry_dsn=
 
+# Miscellaneous (not required)
+# set to true to use <esi:include> tags in place of form authenticity tokens
+enable_esi=
+
 #
 # End of application environment variables
 #

--- a/app/controllers/csrf_protection_controller.rb
+++ b/app/controllers/csrf_protection_controller.rb
@@ -1,0 +1,14 @@
+class CsrfProtectionController < ActionController::Base
+  include ActionView::Helpers::TagHelper
+
+  def meta_tags
+    param = tag("meta", name: "csrf-param", content: "authenticity_token")
+    token = tag("meta", name: "csrf-token", content: form_authenticity_token)
+    render inline: param+token
+  end
+
+  def authenticity_token
+    render inline: tag("input", type: "hidden", name: "authenticity_token", id: "authenticity_token",
+                       value: form_authenticity_token)
+  end
+end

--- a/app/helpers/csrf_protection_helper.rb
+++ b/app/helpers/csrf_protection_helper.rb
@@ -1,0 +1,17 @@
+module CsrfProtectionHelper
+  def csrf_meta_tags
+    if Rails.application.config.esi_enabled
+      tag("esi:include", src: meta_tags_path(format: :html))
+    else
+      super
+    end
+  end
+
+  def token_tag(token=nil)
+    if Rails.application.config.esi_enabled
+      tag("esi:include", src: authenticity_token_path(format: :html))
+    else
+      super(token)
+    end
+  end
+end

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -1,16 +1,16 @@
 <div class="row">
   <div class="email-signup center-block">
     <%= form_for :subscription, url: subscriptions_path, remote: true,
-        html: { id: 'subscription-form', class: 'form-inline', role: "form" } do |f| -%>
-      <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-      <%= f.hidden_field :mailing_list, value: 'effector' -%>
+                  html: { id: "subscription-form", class: "form-inline", role: "form" } do |f| -%>
+      <%= token_tag(form_authenticity_token) %>
+      <%= f.hidden_field :mailing_list, value: "effector" -%>
       <div class="form-group">
-        <%= f.label :email, 'Email address', class: 'sr-only' -%>
+        <%= f.label :email, "Email address", class: "sr-only" -%>
         <%= f.email_field :email, value: current_email,
-          class: "form-control", placeholder: "your@email.com", required: "required" -%>
+                          class: "form-control", placeholder: "your@email.com", required: "required" -%>
       </div>
       <%= f.submit "Get email alerts", class: "btn btn-default", name: "commit" -%>
     <% end %>
-    <%= render 'tools/loading' -%>
+    <%= render "tools/loading" -%>
   </div>
 </div>

--- a/app/views/tools/_mailing_list.html.erb
+++ b/app/views/tools/_mailing_list.html.erb
@@ -7,14 +7,14 @@
     </div>
     <div class="tool-body">
       <%= form_for :subscription, url: subscriptions_path, remote: true,
-        html: { id: 'subscription-form', class: '', role: "form" } do |f| -%>
-      <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-      <%= f.hidden_field :mailing_list, value: 'effector' -%>
-          <fieldset>
-        <%= f.email_field :email, id: :email, value: current_email,
-          class: "form-control", placeholder: "Email", "aria-label": "Email" -%>
-          </fieldset>
-      <%= f.submit 'Subscribe', class: 'btn', name: "commit" -%>
+                    html: { id: "subscription-form", class: "", role: "form" } do |f| -%>
+        <%= token_tag(form_authenticity_token) %>
+        <%= f.hidden_field :mailing_list, value: "effector" -%>
+        <fieldset>
+          <%= f.email_field :email, id: :email, value: current_email,
+                            class: "form-control", placeholder: "Email", "aria-label": "Email" -%>
+        </fieldset>
+        <%= f.submit "Subscribe", class: "btn", name: "commit" -%>
       <% end %>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -161,7 +161,7 @@
           <%= t :organization_abbreviation -%> to keep a record of actions I take
           on the site, to be used for features like leaderboards or to give out
           prizes to the most active action-takers.
-          <%= tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => form_authenticity_token) %>
+          <%= token_tag(form_authenticity_token) %>
         </div>
         <%= submit_tag "Save", class: 'shown-if-no-js btn btn-sm btn-red-outline' %>
       <% end -%>

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,7 @@ module Actioncenter
     config.congress_forms_url = Rails.application.secrets.congress_forms_url
     config.time_zone = Rails.application.secrets.time_zone || 'Eastern Time (US & Canada)'
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.esi_enabled = !!ENV["ENABLE_ESI"]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,6 @@ module Actioncenter
     config.time_zone = Rails.application.secrets.time_zone || 'Eastern Time (US & Canada)'
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.esi_enabled = !!ENV["ENABLE_ESI"]
+    config.esi_enabled = (ENV["enable_esi"] == "true")
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,4 +46,10 @@ Actioncenter::Application.configure do
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
   config.assets.debug = false
+
+  if config.esi_enabled
+    # Expand <esi:include> tags in response
+    require "esi_middleware"
+    config.middleware.use "EsiMiddleware"
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,11 @@ Actioncenter::Application.routes.draw do
                                              sign_up:  'register'},
                                controllers: {sessions: 'sessions', registrations: 'registrations'}
 
+  scope :csrf_protection, controller: "csrf_protection" do
+    get :meta_tags
+    get :authenticity_token
+  end
+
   devise_scope :user do
     get "/sessions/password_reset" => "sessions#password_reset"
   end

--- a/lib/esi_middleware.rb
+++ b/lib/esi_middleware.rb
@@ -1,0 +1,39 @@
+
+class EsiMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    original_logger_level = ActionController::Base.logger.level
+
+    status, headers, body = @app.call(env)
+    if headers["Content-Type"] =~ /^text\/html\b/
+      ActionController::Base.logger.level = Logger::WARN
+
+      includes = {}
+      re = /<esi:include\s+src\=\"(.*?)\"\s*\/?>/i
+      fixed_body = body.body.gsub(re) do |esi|
+        path = esi.match(re)[1]
+
+        unless includes[path]
+          esi_status, esi_headers, esi_body = @app.call(env.merge("PATH_INFO" => path))
+
+          if (200...300).include?(esi_status)
+            includes[path] = esi_body.body
+          else
+            return [500, {}, ["Edge side include error: #{path} returned HTTP #{esi_status}"]]
+          end
+        end
+
+        includes[path]
+      end
+
+      body = [fixed_body]
+    end
+
+    [status, headers, body]
+  ensure
+    ActionController::Base.logger.level = original_logger_level
+  end
+end

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe WelcomeController, type: :controller do
 
@@ -7,4 +7,23 @@ RSpec.describe WelcomeController, type: :controller do
     expect(response.code).to eq "200"
   end
 
+  context "Rails.application.config.esi_enabled" do
+    render_views
+    it "should use edge side includes for csrf tags" do
+      allow(Rails.application.config).to receive(:esi_enabled){ true }
+
+      get :index
+      expect(response.body).to include(%(<esi:include src="/csrf_protection/meta_tags.html" />))
+    end
+  end
+
+  context "!Rails.application.config.esi_enabled" do
+    render_views
+    it "should not use edge side includes for csrf tags" do
+      allow(Rails.application.config).to receive(:esi_enabled){ false }
+
+      get :index
+      expect(response.body).not_to include(%(<esi:include src="/csrf_protection/meta_tags.html" />))
+    end
+  end
 end


### PR DESCRIPTION
Related: https://www.fastly.com/blog/caching-uncacheable-csrf-security