### PR TITLE
Redirect "back" after admins enter strong password

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,10 @@ class ApplicationController < ActionController::Base
   # if the current_user's password is expired, force them to the reset page
   # or lock them out of secure areas
   def lock_users_with_expired_passwords!
-    redirect_to '/sessions/password_reset' if current_user.password_expired?
+    if current_user.password_expired?
+      verifier = ActiveSupport::MessageVerifier.new(Rails.application.secrets.secret_key_base)
+      redirect_to sessions_password_reset_path(continue: verifier.generate(request.path))
+    end
   end
 
   def user_is_being_told_to_reset_pass_or_is_resetting_pass?

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -36,7 +36,12 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def after_update_path_for(resource)
-    edit_registration_path resource
+    if params[:continue].present?
+      verifier = ActiveSupport::MessageVerifier.new(Rails.application.secrets.secret_key_base)
+      verifier.verify(params[:continue])
+    else
+      edit_registration_path(resource)
+    end
   end
 
   def set_create_notice

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -31,7 +31,7 @@ class SessionsController < Devise::SessionsController
   end
 
   def password_reset
-    if (user_signed_in?)
+    if user_signed_in?
       @user = current_user
     else
       redirect_to '/', :flash => { :notice => "You need to be logged in to reset your password!" }

--- a/app/views/sessions/password_reset.html.erb
+++ b/app/views/sessions/password_reset.html.erb
@@ -17,6 +17,7 @@
           </p>
         </div>
         <%= form_for @user, url: '/', html: { :method => :put } do |f| %>
+          <%= hidden_field_tag :continue, params[:continue] if params[:continue].present? %>
           <div class='container-fluid edit-action'>
             <div class="tabs-left">
 


### PR DESCRIPTION
Fixes #270. I decided to redirect to the original page they were accessing before the interruption. The path is saved through a signed param.