### PR TITLE
Twitter actions without javascript

### DIFF
--- a/app/assets/javascripts/application/templates/tweet_individual.jst.ejs
+++ b/app/assets/javascripts/application/templates/tweet_individual.jst.ejs
@@ -1,6 +1,0 @@
-<div class='tweet-individual'>
-  <% if(image_url){ %>
-    <img src="<%= image_url %>" class='individual'>
-  <% } %>
-  <a class="btn btn-tweet btn-default individual" data-twitter-id="@<%= twitter_id %>" target="_blank" href="https://twitter.com/intent/tweet?status=.@<%= twitter_id + ' ' + message %>&related=<%= related %>"><i class='icon-twitter-1'></i> Tweet <%= twitter_id %></a>
-</div>

--- a/app/assets/javascripts/application/templates/tweet_refresh_button.jst.ejs
+++ b/app/assets/javascripts/application/templates/tweet_refresh_button.jst.ejs
@@ -1,1 +1,0 @@
-<button class='btn btn-success btn-sm tweet-refresh'><i class="icon-loop"></i> Display another <%= display_num %></button>  

--- a/app/assets/javascripts/application/tools/tweet.js
+++ b/app/assets/javascripts/application/tools/tweet.js
@@ -75,29 +75,13 @@ $(document).on('ready', function() {
   var related = $("#tweet-tool").data("tweet-related");
   var message = $("#tweet-tool").data("tweet-message");
   var targets = $("#tweet-tool").data("tweet-targets");
-  if(typeof targets != "undefined"){
-    var display_num = 3;
-    display_random_targets(display_num);
-  }
 
-  function display_random_targets(display_num){
-    var random_targets = _.sample(targets, display_num);
-    var refresh_button = "";
+  $(".tweet-refresh").on("click", function() {
+    var targets = $("#tweet-tool-container .tweet-individual");
+    var display_num = targets.filter(":visible").length;
+    targets = _.sample($.makeArray(targets), display_num);
 
-    if(targets.length > display_num){
-      var refresh_button = JST['application/templates/tweet_refresh_button']({display_num: display_num});
-    }
-
-    $('#tweet-tool-container').html(_.map(random_targets, function(target){
-      return JST['application/templates/tweet_individual'](_.extend({
-        message: encodeURIComponent(message),
-        related: related
-      }, target));
-    }).join("") + refresh_button);
-    height_changed();
-
-    $(".tweet-refresh").on('click', function(){
-      display_random_targets(display_num);
-    });
-  }
+    $(".tweet-individual").hide();
+    $(targets).show();
+  });
 });

--- a/app/assets/stylesheets/action_page.css.scss
+++ b/app/assets/stylesheets/action_page.css.scss
@@ -257,6 +257,7 @@
 
 #tools #tweet-tool {
   text-align: center;
+  padding-bottom: 15px;
 
   .tool-body {
     padding-bottom: 0px;
@@ -267,7 +268,11 @@
   }
 
   .newsletter-subscription {
-    margin: 0 15px 10px 15px;
+    margin: 0 15px;
+
+    input[type=submit] {
+      margin-bottom: 0;
+    }
   }
 
   input[type=submit] {

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -4,4 +4,8 @@ class Tweet < ActiveRecord::Base
   alias :targets :tweet_targets
   accepts_nested_attributes_for :tweet_targets, reject_if: :all_blank,
     allow_destroy: true
+
+  def target_congress?
+    target_house? || target_senate?
+  end
 end

--- a/app/views/tools/_tweet.html.erb
+++ b/app/views/tools/_tweet.html.erb
@@ -5,51 +5,51 @@
   <div class="tool-container">
     <div class="tool-heading"><h3 class="tool-title"><%= @tweet.cta -%></h3></div>
     <div class="tool-body">
-      <% if !@reps.present? && (@tweet.target_house? || @tweet.target_senate?) %>
-        <div id="tweet-message-wrapper" style="display: none">
-          <textarea class="form-control" id="tweet-message"><%= @tweet.message.html_safe -%></textarea>
-        </div>
-        <% if @tweet.targets.count > 0 %>
-          <h3 class="twitter-tool-label" style="display: none"><em>Individuals</em></h3>
-          <div id="tweet-tool-container" style="display: none"></div>
-        <% end %>
-        <h3 class="twitter-tool-label" style="display: none"><em>Your Representatives</em></h3>
-      <% else %>
-        <textarea class="form-control" id="tweet-message"><%= @tweet.message.html_safe -%></textarea>
-        <% if @tweet.targets.count > 0 %>
+      <div id="tweet-message-wrapper"<%= %( style="display: none").html_safe if @tweet.target_congress? %>>
+        <textarea class="form-control"><%= @tweet.message.html_safe -%></textarea>
+      </div>
+
+      <% if @tweet.targets.present? %>
+        <div id="tweet-tool-container"<%= %( style="display: none").html_safe if @tweet.target_congress? %>>
           <h3 class="twitter-tool-label"><em>Individuals</em></h3>
-          <div id="tweet-tool-container"></div>
-        <% end %>
+          <% initial_targets = @tweet.targets.sample(3) %>
+          <% @tweet.targets.each do |target| %>
+            <div class="tweet-individual"<%= %( style="display: none").html_safe unless initial_targets.include?(target) %>>
+              <% if target.image_url.present? %>
+                <img src="<%= target.image_url %>" class="individual">
+              <% end %>
+              <a class="btn btn-tweet btn-default individual" data-twitter-id="@<%= target.twitter_id %>" target="_blank" href="https://twitter.com/intent/tweet?status=.@<%= target.twitter_id %> <%= @tweet.message %>&related=<%= Rails.application.config.twitter_related.to_a.join(",") %>"><i class="icon-twitter-1"></i> Tweet <%= target.twitter_id %></a>
+            </div>
+          <% end %>
+
+          <% if @tweet.targets.size > 3 %>
+            <button class="btn btn-success btn-sm tweet-refresh"><i class="icon-loop"></i> Display another 3</button>
+          <% end %>
+        </div>
       <% end %>
-      <div id="tweet-tool-container" style="<%= !@reps.present? && (@tweet.target_house? || @tweet.target_senate?) ? "display: none" : "" %>"></div>
-      <% if @tweet.target_house? || @tweet.target_senate? -%>
 
-        <% if @reps.present? -%>
-          <h3 class="twitter-tool-label"><em>Your Representatives</em></h3>
-          <%= render "action_page/reps" -%>
-        <% else -%>
-
-          <form class="tweet-tool validate" action="">
-            <div class="form-group">
-              <label for="street_address">Street address</label>
-              <input class="form-control" type=text id="street_address" required>
-            </div>
-            <div class="form-group">
-              <label for="zipcode">Zip Code</label>
-              <input class="form-control" type=text name="zipcode" id="zipcode" required>
-            </div>
-            <%= render "tools/save_my_info_option", info: %w[address zipcode] -%>
-            <input type=submit class="btn action" value="Look up your reps">
-            <%= render "tools/loading" -%>
-          </form>
-        <% end -%>
+      <% if @tweet.target_congress? %>
+        <h3 class="twitter-tool-label" style="display: none"><em>Your Representatives</em></h3>
+        <form class="tweet-tool validate" action="">
+          <div class="form-group">
+            <label for="street_address">Street address</label>
+            <input class="form-control" type=text id="street_address" required>
+          </div>
+          <div class="form-group">
+            <label for="zipcode">Zip Code</label>
+            <input class="form-control" type=text name="zipcode" id="zipcode" required>
+          </div>
+          <%= render "tools/save_my_info_option", info: %w[address zipcode] -%>
+          <input type=submit class="btn action" value="Look up your reps">
+          <%= render "tools/loading" -%>
+        </form>
       <% end -%>
     </div>
 
     <input type="hidden" name="action-id" value="<%= @actionPage.id -%>">
   </div>
 
-  <% if (@tweet.target_house? || @tweet.target_senate?) && !@reps.present?-%>
+  <% if @tweet.target_congress? && !@reps.present? -%>
     <p class="privacy-notice">
       This tool uses <a href="http://smartystreets.com/legal/privacy-policy" target="_blank">Smarty Streets</a>' API.
     (<a class="privacy-notice-popover" href="#"

--- a/app/views/tools/_tweet.html.erb
+++ b/app/views/tools/_tweet.html.erb
@@ -29,20 +29,28 @@
       <% end %>
 
       <% if @tweet.target_congress? %>
-        <h3 class="twitter-tool-label" style="display: none"><em>Your Representatives</em></h3>
-        <form class="tweet-tool validate" action="">
-          <div class="form-group">
-            <label for="street_address">Street address</label>
-            <input class="form-control" type=text id="street_address" required>
-          </div>
-          <div class="form-group">
-            <label for="zipcode">Zip Code</label>
-            <input class="form-control" type=text name="zipcode" id="zipcode" required>
-          </div>
-          <%= render "tools/save_my_info_option", info: %w[address zipcode] -%>
-          <input type=submit class="btn action" value="Look up your reps">
-          <%= render "tools/loading" -%>
-        </form>
+        <div class="with-js">
+          <h3 class="twitter-tool-label" style="display: none"><em>Your Representatives</em></h3>
+          <form class="tweet-tool validate" action="">
+            <div class="form-group">
+              <label for="street_address">Street address</label>
+              <input class="form-control" type=text id="street_address" required>
+            </div>
+            <div class="form-group">
+              <label for="zipcode">Zip Code</label>
+              <input class="form-control" type=text name="zipcode" id="zipcode" required>
+            </div>
+            <%= render "tools/save_my_info_option", info: %w[address zipcode] -%>
+            <input type=submit class="btn action" value="Look up your reps">
+            <%= render "tools/loading" -%>
+          </form>
+        </div>
+        <div class="without-js">
+          <h4><strong>Our representative lookup tool requires javascript.</strong></h4>
+          <p>If your browser doesn't support javascript or you prefer not to enable javascript on this site, you can find your legislators' contact information via the <a target="_blank" href="http://www.house.gov/representatives/find/">House</a> and <a target="_blank" href="https://www.senate.gov/general/contact_information/senators_cfm.cfm">Senate</a> websites.</p>
+          <p>The tweet for this campaign is:</p>
+          <textarea class="form-control"><%= @tweet.message.html_safe -%></textarea>
+        </div>
       <% end -%>
     </div>
 
@@ -50,7 +58,7 @@
   </div>
 
   <% if @tweet.target_congress? && !@reps.present? -%>
-    <p class="privacy-notice">
+    <p class="privacy-notice with-js">
       This tool uses <a href="http://smartystreets.com/legal/privacy-policy" target="_blank">Smarty Streets</a>' API.
     (<a class="privacy-notice-popover" href="#"
       data-container="body"

--- a/app/views/tools/_tweet.html.erb
+++ b/app/views/tools/_tweet.html.erb
@@ -1,52 +1,52 @@
 <div class="tool <%= tweet_tool_classes -%>" id="tweet-tool"
      data-tweet-targets="<%= @tweet.targets.to_json(only: :twitter_id, methods: :image_url) %>"
      data-tweet-message="<%= @tweet.message %>"
-     data-tweet-related="<%= Rails.application.config.twitter_related.to_a.join(',') %>">
+     data-tweet-related="<%= Rails.application.config.twitter_related.to_a.join(",") %>">
   <div class="tool-container">
     <div class="tool-heading"><h3 class="tool-title"><%= @tweet.cta -%></h3></div>
     <div class="tool-body">
       <% if !@reps.present? && (@tweet.target_house? || @tweet.target_senate?) %>
-        <div id='tweet-message-wrapper' style='display: none;'>
-          <textarea class='form-control' id="tweet-message"><%= @tweet.message.html_safe -%></textarea>
+        <div id="tweet-message-wrapper" style="display: none">
+          <textarea class="form-control" id="tweet-message"><%= @tweet.message.html_safe -%></textarea>
         </div>
         <% if @tweet.targets.count > 0 %>
-          <h3 class='twitter-tool-label' style='display: none;'><em>Individuals</em></h3>
-          <div id='tweet-tool-container' style='display: none;'></div>
+          <h3 class="twitter-tool-label" style="display: none"><em>Individuals</em></h3>
+          <div id="tweet-tool-container" style="display: none"></div>
         <% end %>
-        <h3 class='twitter-tool-label' style='display: none;'><em>Your Representatives</em></h3>
+        <h3 class="twitter-tool-label" style="display: none"><em>Your Representatives</em></h3>
       <% else %>
-        <textarea class='form-control' id="tweet-message"><%= @tweet.message.html_safe -%></textarea>
+        <textarea class="form-control" id="tweet-message"><%= @tweet.message.html_safe -%></textarea>
         <% if @tweet.targets.count > 0 %>
-          <h3 class='twitter-tool-label'><em>Individuals</em></h3>
-          <div id='tweet-tool-container'></div>
+          <h3 class="twitter-tool-label"><em>Individuals</em></h3>
+          <div id="tweet-tool-container"></div>
         <% end %>
       <% end %>
-      <div id='tweet-tool-container' style='<%= !@reps.present? && (@tweet.target_house? || @tweet.target_senate?) ? "display: none;" : "" %>'></div>
+      <div id="tweet-tool-container" style="<%= !@reps.present? && (@tweet.target_house? || @tweet.target_senate?) ? "display: none" : "" %>"></div>
       <% if @tweet.target_house? || @tweet.target_senate? -%>
 
         <% if @reps.present? -%>
-          <h3 class='twitter-tool-label'><em>Your Representatives</em></h3>
-          <%= render 'action_page/reps' -%>
+          <h3 class="twitter-tool-label"><em>Your Representatives</em></h3>
+          <%= render "action_page/reps" -%>
         <% else -%>
 
-          <form class='tweet-tool validate' action="">
+          <form class="tweet-tool validate" action="">
             <div class="form-group">
               <label for="street_address">Street address</label>
-              <input class='form-control' type=text id="street_address" required>
+              <input class="form-control" type=text id="street_address" required>
             </div>
             <div class="form-group">
               <label for="zipcode">Zip Code</label>
-              <input class='form-control' type=text name="zipcode" id="zipcode" required>
+              <input class="form-control" type=text name="zipcode" id="zipcode" required>
             </div>
-            <%= render 'tools/save_my_info_option', info: %w[address zipcode] -%>
-            <input type=submit class='btn action' value="Look up your reps">
-            <%= render 'tools/loading' -%>
+            <%= render "tools/save_my_info_option", info: %w[address zipcode] -%>
+            <input type=submit class="btn action" value="Look up your reps">
+            <%= render "tools/loading" -%>
           </form>
         <% end -%>
       <% end -%>
     </div>
 
-    <input type='hidden' name='action-id' value='<%= @actionPage.id -%>'>
+    <input type="hidden" name="action-id" value="<%= @actionPage.id -%>">
   </div>
 
   <% if (@tweet.target_house? || @tweet.target_senate?) && !@reps.present?-%>


### PR DESCRIPTION
Fixes #273.

I allow the tweet target list and message to be displayed to no-js visitors. That way they at least know what to tweet and who the accounts to tweet at are, and they can use twitter in whatever nojs manner they usually do.

When the tweets target congress, I replace the tool body with a message saying our rep lookup tool requires javascript and referring them to the official congress website to lookup contact info for their legislator (same as the call tool). I also include the suggested tweet message.