### PR TITLE
Don't poll updated at

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -112,25 +112,18 @@ $(document).on('ready', function() {
     history.pushState(null,null,'#' + anchor);
   });
 
-  var updated_at = $('#action_page_updated_at');
-  if (updated_at.length > 0) {
-    var t = window.setInterval(function() {
-      $.get(updated_at.data('url'), { updated_at: updated_at.val() },
-        function(data) {
-          if (data.updated) {
-            $('#action-page-form').submit(function(e) {
-              if (confirm('Are you sure? This page has been updated since you started editing.')) {
-                return;
-              }
-              e.preventDefault();
-            });
-            window.clearInterval(t);
-          }
-        }
-      );
-    }, 10000);
-  }
+  $("#action-page-form.edit_action_page").on("submit.check_timestamp", function(e) {
+    e.preventDefault();
+    e.stopPropagation();
 
+    var form = this;
+    $.get(form.action + ".json", function(record) {
+      if (new Date(record.updated_at) <= new Date(form.dataset.timestamp)
+          || confirm("Are you sure? This page has been updated since you started editing.")) {
+        $(form).off("submit.check_timestamp").submit();
+      }
+    });
+  });
 
   var preview_button = $('#action-page-preview').click(function() {
     var form = $('#action-page-form').clone()

--- a/app/controllers/admin/action_pages_controller.rb
+++ b/app/controllers/admin/action_pages_controller.rb
@@ -81,6 +81,7 @@ class Admin::ActionPagesController < Admin::ApplicationController
   end
 
   def show
+    render json: @actionPage
   end
 
   def updated_at

--- a/app/controllers/admin/action_pages_controller.rb
+++ b/app/controllers/admin/action_pages_controller.rb
@@ -146,8 +146,7 @@ class Admin::ActionPagesController < Admin::ApplicationController
   private
 
   def set_action_page
-    @actionPage = ActionPage.friendly.find (params[:id] || params[:action_page_id])
-    raise ActiveRecord::RecordNotFound unless @actionPage
+    @actionPage = ActionPage.friendly.find(params[:id] || params[:action_page_id])
   end
 
   def set_date_from_params

--- a/app/controllers/admin/action_pages_controller.rb
+++ b/app/controllers/admin/action_pages_controller.rb
@@ -84,13 +84,6 @@ class Admin::ActionPagesController < Admin::ApplicationController
     render json: @actionPage
   end
 
-  def updated_at
-    if params[:updated_at]
-      updated = Time.zone.parse(params[:updated_at]) < @actionPage.updated_at
-    end
-    render json: {updated: updated, updated_at: @actionPage.updated_at}
-  end
-
   def publish
     @actionPage.update(published: true)
     redirect_to admin_action_pages_path, notice: "Published page: #{@actionPage.title}"

--- a/app/views/admin/action_pages/_form.html.erb
+++ b/app/views/admin/action_pages/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for @actionPage,
   url: { controller: :action_pages,
          action: (@actionPage.new_record? ? :create : :update)},
-  :html => { id: 'action-page-form', multipart: true }  do |f| -%>
+  :html => { id: "action-page-form", multipart: true, :"data-timestamp" => @actionPage.updated_at.as_json }  do |f| -%>
 
   <% if can?(:administer_actions) %>
     <%= render partial: 'top_bar_authoring_controls', :locals => {:f => f} %>
@@ -31,12 +31,7 @@
     </div><!-- .tabs-left -->
   </div><!-- .container.edit-action -->
 
-  <input id='anchor' type=hidden name=anchor>
-  <% unless @actionPage.new_record? -%>
-  <%= f.hidden_field :updated_at,
-      value: f.object.updated_at.strftime("%Y/%m/%d %H:%M:%S.%9N %Z %z"),
-      data: { url: admin_action_page_updated_at_path(@actionPage) } -%>
-  <% end -%>
+  <input id="anchor" type="hidden" name="anchor">
 <% end -%>
 
 <!-- Button trigger modal -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,6 @@ Actioncenter::Application.routes.draw do
     resources :topic_categories, :topic_sets, :topics
 
     resources :action_pages do
-      get :updated_at
       get :publish
       get :unpublish
       get :destroy

--- a/spec/controllers/admin/action_pages_controller_spec.rb
+++ b/spec/controllers/admin/action_pages_controller_spec.rb
@@ -55,34 +55,4 @@ RSpec.describe Admin::ActionPagesController, type: :controller do
       end
     end
   end
-
-  describe "GET #updated_at" do
-    before{ login_as_admin }
-
-    def tparam(time)
-      time.strftime("%Y/%m/%d %H:%M:%S.%9N %Z %z")
-    end
-
-    it ".updated field should be false if params[:updated_at] is gte action_page.updated_at" do
-      get :updated_at, { action_page_id: petition_action_page.to_param,
-                         updated_at: tparam(petition_action_page.updated_at) }
-
-      expect(response.content_type).to eq("application/json")
-      expect(JSON.parse(response.body)["updated"]).to eq(false)
-
-      get :updated_at, { action_page_id: petition_action_page.to_param,
-                         updated_at: tparam(petition_action_page.updated_at + 2) }
-
-      expect(response.content_type).to eq("application/json")
-      expect(JSON.parse(response.body)["updated"]).to eq(false)
-    end
-
-    it ".updated field should be true if params[:updated_at] is lt action_page.updated_at" do
-      get :updated_at, { action_page_id: petition_action_page.to_param,
-                         updated_at: tparam(petition_action_page.updated_at - 0.1) }
-
-      expect(response.content_type).to eq("application/json")
-      expect(JSON.parse(response.body)["updated"]).to eq(true)
-    end
-  end
 end


### PR DESCRIPTION
This branch changes the approach to concurrent modification avoidance from polling the record's updated_at timestamp to checking it once on save. It's slightly more accurate, since the polling happened once per 10 seconds, but moreover keeps the logs cleaner and reduces load on the server.