### PR TITLE
Remove dead/unnecessary cookies and flash notices

### DIFF
--- a/app/controllers/action_page_controller.rb
+++ b/app/controllers/action_page_controller.rb
@@ -23,7 +23,6 @@ class ActionPageController < ApplicationController
 
     @actionPages = @actionPages.categorized(params[:category]) if params[:category].present?
 
-    #request.session_options[:skip] = true  # removes session data
     response.headers['Cache-Control'] = 'public, no-cache'
     response.headers['Surrogate-Control'] = "max-age=120"
     response.headers['Access-Control-Allow-Origin'] = "*"
@@ -143,8 +142,6 @@ private
                               country_code: current_country_code,
                               email: current_email }
 
-    #request.session_options[:skip] = true  # removes session data
-    #response.headers.delete 'Set-Cookie'
     response.headers['Cache-Control'] = 'public, no-cache'
     response.headers['Surrogate-Control'] = "max-age=120"
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -34,6 +34,7 @@ class SessionsController < Devise::SessionsController
     if user_signed_in?
       @user = current_user
     else
+      # Should never end up here
       redirect_to '/', :flash => { :notice => "You need to be logged in to reset your password!" }
     end
   end

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -38,7 +38,6 @@ class ToolsController < ApplicationController
     sbResponse = RestClient.get 'https://socialbuttonsserver.herokuapp.com/',
       {:params => {:url => params[:url], :networks => 'facebook,twitter,googleplus'}}
 
-    request.session_options[:skip] = true  # removes session data
     response.headers['Cache-Control'] = 'public, no-cache'
     response.headers['Surrogate-Control'] = "max-age=300"
 
@@ -98,7 +97,6 @@ class ToolsController < ApplicationController
       respond_to do |format|
         format.json {   render :json => {success: true}, :status => 200 }
         format.html do
-          flash[:notice] = 'You successfully signed the petition'
           begin
             url = URI.parse(request.referer)
             url.query = [url.query.presence, 'thankyou=1'].join('&')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -426,9 +426,6 @@ module ApplicationHelper
       p = params.clone
       p.delete(:email)
       current_user.update_attributes p
-    else
-      session[:user] ||= {}
-      session[:user].merge! params
     end
   end
 
@@ -464,8 +461,7 @@ module ApplicationHelper
   end
 
   def current_user_data(field)
-    session[:user] ||= {}
     return nil unless user_session_data_whitelist.include? field
-    current_user.try(field) || session[:user][field]
+    current_user.try(field)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,12 +106,6 @@ class User < ActiveRecord::Base
     admin? || activist? || collaborator?
   end
 
-  def self.new_with_session(params, session)
-    email = session[:user].with_indifferent_access[:email] if session[:user]
-    params.reverse_merge!(email: email)
-    new params
-  end
-
   # This is here for collission avoidance when generating new user names in tests
   def self.next_id
     self.last.nil? ? 1 : self.last.id + 1


### PR DESCRIPTION
This branch removes some references to `request.session` which should be dead anyway. This is true except for one `flash.notice` that was removed -- but it is only displayed to no-js users, and it's clear from the rest of the page that the petition was signed.

As of this branch, I believe the only parts of the app that depend on cookies are either only accessible when logged in, or in response to a POST request, or in certain restricted controllers (`AhoyController`, `CsrfProtectionController`) . After it's merged we can enable some Fastly features that we couldn't use before.