### PR TITLE
Verify authenticity token for petition actions

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -8,7 +8,6 @@ class ToolsController < ApplicationController
   before_filter :create_newsletter_subscription, only: [:call]
   after_filter :deliver_thanks_message, only: [:call, :petition, :email, :message_congress]
   skip_after_filter :deliver_thanks_message, if: :signature_has_errors
-  skip_before_filter :verify_authenticity_token, only: :petition
 
   def call
     ahoy.track "Action",


### PR DESCRIPTION
I'm not sure why this was originally added (git history doesn't go that far back) but I think we can remove it now.