### PR TITLE
Fixed docker-compose.yml.example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Follow these instructions to run the Action Center using Docker (recommended). T
 
 1. Install Docker ([instructions](https://docs.docker.com/engine/installation/)) and Docker Compose ([instructions](https://docs.docker.com/compose/install/)).
 2. `git clone https://github.com/EFForg/action-center-platform.git`
-3. Copy `docker-compose.example.yml` to `docker-compose.yml`, and `.env.example` to `.env`. Fill in the variables in `.env` according to the instructions in that file. See [notable dependencies](#notable-dependencies) for hints.
+3. Copy `docker-compose.yml.example` to `docker-compose.yml`, and `.env.example` to `.env`. Fill in the variables in `.env` according to the instructions in that file. See [notable dependencies](#notable-dependencies) for hints.
 4. Build the docker image: `sudo docker-compose build`
 5. Run the application: `sudo docker-compose up`
 6. In a new tab, get a bash shell with access to your app: `sudo docker-compose exec app bash`.


### PR DESCRIPTION
`docker-compose.example.yml` doesn't exist. Moving to corrected `docker-compose.yml.example`