### PR TITLE
Put the js/no-js class on the embed template

### DIFF
--- a/app/views/layouts/application-blank.html.erb
+++ b/app/views/layouts/application-blank.html.erb
@@ -17,6 +17,11 @@
     <% end %>
     <%= yield(:head) if content_for?(:head) -%>
     <%= csrf_meta_tags %>
+
+    <script type="text/javascript">
+      // Remove the no-js class from <html> if js is loading
+      document.documentElement.className = document.documentElement.className.replace("no-js", "js");
+    </script>
   </head>
 
   <body class="<%= current_user ? 'logged-in' : '' %> <%= controller.controller_name  + "-" +action_name %>">


### PR DESCRIPTION
We moved this into the main application template so it would run more quickly, avoiding a weird flash of elements that should be hidden. We need to add it here too so it runs for embeds.