### PR TITLE
Update smartystreets zipcode endpoint

### DIFF
--- a/lib/smarty_streets.rb
+++ b/lib/smarty_streets.rb
@@ -1,7 +1,7 @@
 require 'rest_client'
 module SmartyStreets
   def self.get_city_state(zipcode)
-    url = "https://api.smartystreets.com/zipcode/"
+    url = "https://us-zipcode.api.smartystreets.com/lookup"
     res = post(url, base_params.merge(zipcode: zipcode))
     if res && !res.empty?
       res.first['city_states'].try :first


### PR DESCRIPTION
The old endpoint is causing a 404, but I think it worked as recently as a month ago. This new one matches the docs and seems to work. Trying to find some documentation of an API change.