### PR TITLE
Bot prevention

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ gem 'oauth'
 gem 'email_validator'
 gem 'iso_country_codes'
 gem 'cocoon'                      # Dynamically add and remove nested associations from forms
+gem 'invisible_captcha'           # Prevent form submissions by bots
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api

--- a/app/assets/stylesheets/application/_base.css.scss
+++ b/app/assets/stylesheets/application/_base.css.scss
@@ -332,7 +332,8 @@ Styles for the alert box
       10%, 90% { opacity: 1; transform: translate(0,0); }
    }
 
-.signup-radios {
+.signup-radios,
+.email-signup {
   font-size: 13px;
   margin-bottom:10px;
   margin-top:20px;

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,4 +1,5 @@
 class RegistrationsController < Devise::RegistrationsController
+  invisible_captcha only: :create
   after_filter :set_create_notice, only: :create
 
   # POST /resource

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -18,6 +18,7 @@
             <%= f.label :password_confirmation %>
             <%= f.password_field :password_confirmation, :class => 'form-control', :required => 'required' %>
           </div>
+          <%= invisible_captcha %>
 
           <div class="email-signup">
             I

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,6 +20,11 @@ Capybara.javascript_driver = :poltergeist
 
 WebMock.allow_net_connect!
 
+# Don't prevent form fills by bots during the test run
+InvisibleCaptcha.setup do |config|
+  config.timestamp_enabled = false
+end
+
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any
 # selectors in your step definitions to use the XPath syntax.


### PR DESCRIPTION
Attempt to reduce successful registrations by bots by doing two things:
- rejecting form submissions where a hidden field is filled out. this returns a 200 status and no content.
- rejecting form submissions that take fewer than four seconds. this displays a descriptive error and reloads the fields.

Banning IPs that fill the hidden field is also an option.