### PR TITLE
Wait for request to civicrm in mailing signup test

### DIFF
--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -457,6 +457,9 @@ end
 
 Then(/^"(.*?)" should be signed up for mailings$/) do |email|
   email = email.sub("@", "%40")
+  wait_until {
+    WebMock::WebMockMatcher.new(:post, CiviCRM::supporters_api_url).matches?(nil)
+  }
   WebMock.should have_requested(:post, CiviCRM::supporters_api_url).
     with(body: /.*#{email}.*/)
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -113,3 +113,11 @@ def stub_legislators
 
   allow(CongressMember).to receive(:lookup).and_return([nancy])
 end
+
+def wait_until
+  require "timeout"
+  Timeout.timeout(Capybara.default_max_wait_time) do
+    sleep(0.1) until value = yield
+    value
+  end
+end


### PR DESCRIPTION
Feature tests were failing intermittently because the request to subscribe a new user in civi hadn't completed yet. There's no success event we can look for on the client so I added a wait loop.

Capybara removed wait_until, but the creator says it's okay to add it back in https://www.varvet.com/blog/why-wait_until-was-removed-from-capybara/. I think this is a legitimate use.
  
Resolves #349 