### PR TITLE
Store sessions in the database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,7 @@ sentry_dsn=
 
 # Miscellaneous (not required)
 # set to true to use <esi:include> tags in place of form authenticity tokens
+SESSION_DAYS_TRIM_THRESHOLD=365
 enable_esi=
 
 #

--- a/.env.example
+++ b/.env.example
@@ -80,8 +80,8 @@ sentry_dsn=
 
 # Miscellaneous (not required)
 # set to true to use <esi:include> tags in place of form authenticity tokens
-SESSION_DAYS_TRIM_THRESHOLD=365
 enable_esi=
+SESSION_DAYS_TRIM_THRESHOLD=365
 
 #
 # End of application environment variables

--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ gem 'email_validator'
 gem 'iso_country_codes'
 gem 'cocoon'                      # Dynamically add and remove nested associations from forms
 gem 'invisible_captcha'           # Prevent form submissions by bots
+gem 'activerecord-session_store'
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,12 @@ GEM
       activemodel (= 4.2.10)
       activesupport (= 4.2.10)
       arel (~> 6.0)
+    activerecord-session_store (1.1.0)
+      actionpack (>= 4.0, < 5.2)
+      activerecord (>= 4.0, < 5.2)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0, < 5.2)
     activesupport (4.2.10)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -449,6 +455,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   acts_as_paranoid!
   ahoy_matey
   aws-sdk (< 2.0)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -122,7 +122,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 1.year
 
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Actioncenter::Application.config.session_store :cookie_store, key: '_actioncenter_session'
+Actioncenter::Application.config.session_store :active_record_store, key: '_actioncenter_session'

--- a/db/migrate/20180124013711_add_sessions_table.rb
+++ b/db/migrate/20180124013711_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170831214704) do
+ActiveRecord::Schema.define(version: 20180124013711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -262,6 +262,16 @@ ActiveRecord::Schema.define(version: 20170831214704) do
     t.integer  "goal"
     t.boolean  "enable_affiliations", default: false
   end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "signatures", force: :cascade do |t|
     t.integer  "petition_id"

--- a/docker/crontab
+++ b/docker/crontab
@@ -1,3 +1,4 @@
 0 * * * * root su -s/bin/bash www-data -c '. /var/www/.profile && cd /opt/actioncenter && bundle exec rake signatures:deduplicate' >>/proc/1/fd/1 2>&1
 0 0 * * * root su -s/bin/bash www-data -c '. /var/www/.profile && cd /opt/actioncenter && bundle exec rake congress:update'        >>/proc/1/fd/1 2>&1
+0 0 * * * root su -s/bin/bash www-data -c '. /var/www/.profile && cd /opt/actioncenter && bundle exec rake db:sessions:trim'        >>/proc/1/fd/1 2>&1
 


### PR DESCRIPTION
This PR moves session storage to the backend in response to Redmine #14934. 

It creates a database record for ever unique visitor to the site. Currently we already create database records for each action page view using Ahoy, but we should be aware of this in case we run into performance issues. 

I added a cron job to trim sessions for the database that are over a year old. I'm not sure what the session duration is for the action center - it looks like we're using Devise's default of 2 weeks, but that seems surprisingly short, so I'm checking that I actually get logged out after that time frame. If that's the case we should make it longer, and either way it should match the amount of time we keep sessions around in the database.