### PR TITLE
Return a friendly error when admin tasks can't find user

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -20,7 +20,7 @@ namespace :users do
   task :add_admin, [:email] => :environment do |t, args|
     email = args[:email]
     u = User.find_by_email(email)
-    next(puts "I couldn't find a user with the email '#{email}'.") unless u
+    abort("I couldn't find a user with the email '#{email}'.") unless u
 
     u.admin = true
     if u.save

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -6,16 +6,22 @@ namespace :users do
     end.sort
     puts admins.empty? ? "No Admin Users" : admins
   end
+
   desc "Remove admin status from an account, given an email"
   task :remove_admin, [:email] => :environment do |t, args|
     u = User.find_by_email(args[:email])
+    abort("I couldn't find a user with the email '#{args[:email]}'.") unless u
+
     u.admin = false
     u.save
   end
+
   desc "Add admin status from an account, given an email"
   task :add_admin, [:email] => :environment do |t, args|
     email = args[:email]
     u = User.find_by_email(email)
+    next(puts "I couldn't find a user with the email '#{email}'.") unless u
+
     u.admin = true
     if u.save
       puts "Successfully granted admin status to #{email}."

--- a/spec/support/exit_code_helpers.rb
+++ b/spec/support/exit_code_helpers.rb
@@ -1,0 +1,27 @@
+RSpec::Matchers.define :exit_with_failure_code do |exp_code|
+  actual = nil
+
+  def supports_block_expectations?
+    true
+  end
+
+  match do |block|
+    begin
+      block.call
+    rescue SystemExit => e
+      actual = e.status
+    end
+    actual and actual == exp_code
+  end
+
+  failure_message do |block|
+    "expected block to call exit(#{exp_code}) but exit" +
+      (actual.nil? ? " not called" : "(#{actual}) was called")
+  end
+  failure_message_when_negated do |block|
+    "expected block not to call exit(#{exp_code})"
+  end
+  description do
+    "expect block to call exit(#{exp_code})"
+  end
+end

--- a/spec/tasks/users_spec.rb
+++ b/spec/tasks/users_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+require "rake"
+
+describe "User-related rake tasks" do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:email) { user.email }
+  let(:run_task) { Rake.application.invoke_task "#{task}[#{email}]" }
+
+  before do
+    Rake.application.rake_require("tasks/users")
+    Rake::Task.define_task(:environment)
+  end
+
+  after { Rake.application[task].reenable }
+
+  describe 'users:add_admin' do
+    let(:task) { "users:add_admin" }
+
+    it 'grants admin status to the given user' do
+      expect(user.reload.admin?).to be_falsey
+      run_task
+      expect(user.reload.admin?).to be_truthy
+    end
+
+    it 'returns a friendly message' do
+      expect { run_task }.to output(
+        /Successfully granted admin status to #{email}./
+      ).to_stdout
+    end
+
+    context "when user can't be updated" do
+      before { allow_any_instance_of(User).to receive(:save).and_return(false) }
+
+      it 'does not grant admin status' do
+        expect(user.reload.admin?).to be_falsey
+        run_task
+        expect(user.reload.admin?).to be_falsey
+      end
+
+      it 'returns a friendly message' do
+        expect { run_task }.to output(
+          /Granting admin status to #{email} failed./
+        ).to_stdout
+      end
+    end
+
+    context 'when user is missing' do
+      let(:email) { 'nobody@nothing.net' }
+
+      it 'returns a friendly message' do
+        expect { run_task }.to output(
+          /I couldn't find a user with the email '#{email}'./
+        ).to_stdout
+      end
+    end
+  end
+
+  describe 'users:remove_admin' do
+    let(:user) { FactoryGirl.create(:user, admin: true) }
+    let(:task) { 'users:remove_admin' }
+
+    it 'grants admin status to the given user' do
+      expect(user.reload.admin?).to be_truthy
+      run_task
+      expect(user.reload.admin?).to be_falsey
+    end
+
+    it 'returns success code' do
+      run_task
+      expect(`echo $?`).to match(/0/)
+    end
+
+    context 'when user is missing' do
+      let(:email) { 'nobody@nothing.net' }
+
+      it 'returns a friendly message' do
+        expect { run_task }.to output(
+          /I couldn't find a user with the email '#{email}'./
+        ).to_stdout
+      end
+
+      it 'returns failure code' do
+        run_task
+        expect(`echo $?`).not_to match(/0/)
+      end
+    end
+  end
+end

--- a/spec/tasks/users_spec.rb
+++ b/spec/tasks/users_spec.rb
@@ -47,14 +47,10 @@ describe "User-related rake tasks" do
     context 'when user is missing' do
       let(:email) { 'nobody@nothing.net' }
 
-      it 'returns a friendly message' do
-        expect { run_task }.to output(
-          /I couldn't find a user with the email '#{email}'./
-        ).to_stdout
-      end
-
       it 'returns failure code' do
-        expect { run_task }.to exit_with_failure_code
+        expect { run_task }.to raise_error(
+          /I couldn't find a user with the email '#{email}'/
+        )
       end
     end
   end
@@ -72,14 +68,10 @@ describe "User-related rake tasks" do
     context 'when user is missing' do
       let(:email) { 'nobody@nothing.net' }
 
-      it 'returns a friendly message' do
-        expect { run_task }.to output(
-          /I couldn't find a user with the email '#{email}'./
-        ).to_stdout
-      end
-
       it 'returns failure code' do
-        expect { run_task }.to exit_with_failure_code(1)
+        expect { run_task }.to raise_error(
+          /I couldn't find a user with the email '#{email}'/
+        )
       end
     end
   end

--- a/spec/tasks/users_spec.rb
+++ b/spec/tasks/users_spec.rb
@@ -52,6 +52,10 @@ describe "User-related rake tasks" do
           /I couldn't find a user with the email '#{email}'./
         ).to_stdout
       end
+
+      it 'returns failure code' do
+        expect { run_task }.to exit_with_failure_code
+      end
     end
   end
 
@@ -65,11 +69,6 @@ describe "User-related rake tasks" do
       expect(user.reload.admin?).to be_falsey
     end
 
-    it 'returns success code' do
-      run_task
-      expect(`echo $?`).to match(/0/)
-    end
-
     context 'when user is missing' do
       let(:email) { 'nobody@nothing.net' }
 
@@ -80,8 +79,7 @@ describe "User-related rake tasks" do
       end
 
       it 'returns failure code' do
-        run_task
-        expect(`echo $?`).not_to match(/0/)
+        expect { run_task }.to exit_with_failure_code(1)
       end
     end
   end


### PR DESCRIPTION
https://github.com/EFForg/action-center-platform/issues/317
When we run `rake users:add_admin[email]` or `rake users:remove_admin[email]`, and no user exists with the given email, the task used to throw `undefined method `admin=' for nil:NilClass`.

And rightly so!  

Instead, task, just tell us that you can't find the user and chill.