### PR TITLE
Make h3s with tooltips look better on small screens

### DIFF
--- a/app/views/tools/_congress_message.html.erb
+++ b/app/views/tools/_congress_message.html.erb
@@ -12,8 +12,8 @@
           <% unless @congress_message_campaign.target_bioguide_ids %>
             <fieldset id="lookup-address">
               <h3>
-                <em><%= @congress_message_campaign.look_up_your_rep_text "Look up your representatives" %></em>
                 <span class="customize-message-popover" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="auto bottom" data-content="<%= @congress_message_campaign.look_up_helper_text "We'll use your address to look up your congressional district and find your representatives." %>">?</span>
+                <em><%= @congress_message_campaign.look_up_your_rep_text "Look up your representatives" %></em>
               </h3>
 
               <div class="form-group">
@@ -28,8 +28,8 @@
           <% end %>
           <fieldset id="customize-message">
             <h3>
-              <em>Customize your message</em>
               <span class="customize-message-popover" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="auto bottom" data-content="<%= @congress_message_campaign.customize_message_helper_text "Add a personal note about why this matters to you. Members of Congress value a customized message much higher than a form letter." %>">?</span>
+              <em>Customize your message</em>
             </h3>
             <div class="form-group">
                 <textarea class="campaign-message form-control" rows="11"><%= @congress_message_campaign.message -%></textarea>

--- a/app/views/tools/_privacy_notice.html.erb
+++ b/app/views/tools/_privacy_notice.html.erb
@@ -1,4 +1,4 @@
 <h3 class="privacy-notice-header">
-  <em>How will EFF use this information?</em>
   <span class="privacy-notice-popover" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="auto bottom" data-content="<%= t :privacy_notice %>">?</span>
+  <em>How will EFF use this information?</em>
 </h3>


### PR DESCRIPTION
https://github.com/EFForg/action-center-platform/issues/316

Before, when the text of the h3 filled most of the container, the tooltip-triggering question mark was forced down onto a new line.  It looked funny.  Now, the text of the h3 wraps around the question mark properly.

Text change is for illustrative purposes only, and not part of the commit.

<img width="308" alt="screen shot 2018-02-01 at 2 53 23 pm" src="https://user-images.githubusercontent.com/1065956/35708010-f2b2a004-0760-11e8-9fa0-d37dfbd68d37.png"><img width="311" alt="screen shot 2018-02-01 at 2 53 32 pm" src="https://user-images.githubusercontent.com/1065956/35708011-f2cd4224-0760-11e8-9bb0-ff9587f18df9.png">
