### PR TITLE
Link users to strong password info from all our Devise password pages

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -9,8 +9,11 @@
           <%= devise_error_messages! %>
           <%= f.hidden_field :reset_password_token %>
 
-          <div class="form-group"><%= f.label :password, "New password" %><br />
-          <%= f.password_field :password, :autofocus => true, :class => 'form-control', :required => 'required' %></div>
+          <div class="form-group">
+            <%= f.label :password, "New password" %>
+            <%= link_to 'How to create strong passwords', 'https://ssd.eff.org/en/module/creating-strong-passwords', class: 'input-note' %>
+            <%= f.password_field :password, :autofocus => true, :class => 'form-control', :required => 'required' %>
+          </div>
 
           <div class="form-group"><%= f.label :password_confirmation, "Confirm new password" %><br />
           <%= f.password_field :password_confirmation, :class => 'form-control', :required => 'required' %></div>

--- a/app/views/sessions/password_reset.html.erb
+++ b/app/views/sessions/password_reset.html.erb
@@ -32,6 +32,7 @@
               <div class="form-group">
                 <div>
                   <%= f.label :password, "New Password" %>
+                  <%= link_to 'How to create strong passwords', 'https://ssd.eff.org/en/module/creating-strong-passwords', class: 'input-note' %> 
                 </div>
                 <div>
                   <%= f.password_field :password, class: "form-control" %>


### PR DESCRIPTION
https://github.com/EFForg/action-center-platform/issues/337
Should have been part of https://github.com/EFForg/action-center-platform/pull/357, probably
<img width="1280" alt="screen shot 2018-02-07 at 5 15 49 pm" src="https://user-images.githubusercontent.com/1065956/35950387-28d9256c-0c2b-11e8-8bf2-672cd1ed93a3.png">


