### PR TITLE
Allow developers to edit page slugs

### DIFF
--- a/app/controllers/admin/action_pages_controller.rb
+++ b/app/controllers/admin/action_pages_controller.rb
@@ -70,9 +70,6 @@ class Admin::ActionPagesController < Admin::ApplicationController
 
     add_twitter_targets
 
-    @actionPage.slug = nil
-    @actionPage.save!
-
     redirect_to( { :action => 'edit', anchor: params[:anchor]}, :notice => "Action Page was successfully updated.")
   end
 

--- a/app/models/action_page.rb
+++ b/app/models/action_page.rb
@@ -35,8 +35,9 @@ class ActionPage < ActiveRecord::Base
   scope :categorized, ->(category){ joins(:category).where(categories: { title: category }) }
 
   def should_generate_new_friendly_id?
-    # create friendly slugs with FriendlyId, but also allow us to set custom slugs
-    slug.blank? || title_changed? || super
+    # create slugs with FriendlyId and respect our custom slugs
+    # set a custom slug with `page.update(slug: new_slug)`
+    title.present? && (slug.blank? || title_changed?)
   end
 
   def call_tool_title

--- a/app/models/action_page.rb
+++ b/app/models/action_page.rb
@@ -34,7 +34,10 @@ class ActionPage < ActiveRecord::Base
 
   scope :categorized, ->(category){ joins(:category).where(categories: { title: category }) }
 
-  def should_generate_new_friendly_id?; true; end # related to friendly_id
+  def should_generate_new_friendly_id?
+    # create friendly slugs with FriendlyId, but also allow us to set custom slugs
+    slug.blank? || title_changed? || super
+  end
 
   def call_tool_title
     call_campaign && call_campaign.title.length > 0 && call_campaign.title || 'Call Your Legislators'


### PR DESCRIPTION
https://github.com/EFForg/action-center-platform/issues/161

This change was made once before, but had to be reverted because it caused some weird id bugs.  This change covers some extra cases, and hopefully won't cause the same bugs; i was unable to replicate them using what i understood of the steps, so, high hopes.

If the bugs reoccur, a next step might be to add a `custom_slug` field to the ActionPage model, and implement `should_generate_new_friendly_id?` as `!custom_slug?`.