### PR TITLE
Make the Resend Unlock page match our other devise pages

### DIFF
--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -151,10 +151,17 @@ span.green-rect {
   }
 }
 
-.passwords-edit, .passwords-new, .confirmations-new, .sessions-new, .registrations-new, .registrations-create,  .confirmations-create, .confirmations-show {
+.passwords-edit,
+.passwords-new,
+.confirmations-new,
+.sessions-new,
+.registrations-new,
+.registrations-create,
+.confirmations-create,
+.confirmations-show,
+.unlocks-new {
   .wrapper {
     background-color: $red;
-    //min-height: 90%;
   }
   .redtop {
     padding-bottom: 3em;

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -9,11 +9,11 @@
 
           <div class="form-group">
             <%= f.label :email %>
-            <%= f.email_field :email, autofocus: true, :class => 'form-control', :required => 'required' %>
+            <%= f.email_field :email, autofocus: true, class: 'form-control', required: 'required' %>
           </div>
 
           <div>
-            <%= f.submit "Resend unlock instructions", :class => 'btn btn-default' %>
+            <%= f.submit "Resend unlock instructions", class: 'btn btn-default' %>
           </div>
         <% end %>
 

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,12 +1,24 @@
-<h2>Resend unlock instructions</h2>
+<div class="redtop">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-4 col-lg-offset-4 col-sm-6 col-sm-offset-3">
+        <h1>Resend unlock instructions</h1>
 
-<%= form_for(resource, :as => resource_name, :url => unlock_path(resource_name), :html => { :method => :post }) do |f| %>
-  <%= devise_error_messages! %>
+        <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+          <%= devise_error_messages! %>
 
-  <div><%= f.label :email %><br />
-  <%= f.email_field :email, :autofocus => true %></div>
+          <div class="form-group">
+            <%= f.label :email %>
+            <%= f.email_field :email, autofocus: true, :class => 'form-control', :required => 'required' %>
+          </div>
 
-  <div><%= f.submit "Resend unlock instructions" %></div>
-<% end %>
+          <div>
+            <%= f.submit "Resend unlock instructions", :class => 'btn btn-default' %>
+          </div>
+        <% end %>
 
-<%= render "devise/shared/links" %>
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
https://github.com/EFForg/action-center-platform/issues/293

Includes some of the comments from https://github.com/EFForg/action-center-platform/pull/294, but not the ones that made this page look unlike the other devise pages.

<img width="1280" alt="screen shot 2018-02-07 at 1 35 36 pm" src="https://user-images.githubusercontent.com/1065956/35944804-a8660138-0c12-11e8-89f2-f6072770bc04.png">
