### PR TITLE
Fix pending Institution#import specs

### DIFF
--- a/app/controllers/admin/institutions_controller.rb
+++ b/app/controllers/admin/institutions_controller.rb
@@ -40,7 +40,7 @@ class Admin::InstitutionsController < Admin::ApplicationController
       names << params["name"]
     end
 
-    Institution.delay.import(names, @actionPage)
+    Institution.delay.import(names, @actionPage) if names.present?
 
     redirect_to [:admin, @actionPage, Institution]
   end

--- a/app/models/action_institution.rb
+++ b/app/models/action_institution.rb
@@ -1,4 +1,12 @@
 class ActionInstitution < ActiveRecord::Base
   belongs_to :institution
   belongs_to :action_page
+
+  # TODO: We should only create one model for each
+  # institution/action_page pair, but I don't know what effects that
+  # will have on the site.
+  # * Check if there are any duplicates in production
+  # * If so, remove them in a way that doesn't break anything else
+  # * Uncomment the following line
+  #validates_uniqueness_of :institution_id, scope: :action_page_id
 end

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -33,4 +33,29 @@ describe Institution do
       expect(petition.action_page.institutions.top(3, first: low_rank.id).to_a).to eq([low_rank, high_rank, mid_rank])
     end
   end
+
+  describe ".import" do
+    let(:action_page) { FactoryGirl.create(:action_page) }
+    let(:institution) { FactoryGirl.create(:institution) }
+    let(:names) do
+      ["University of California, Berkeley",
+       "University of California, Santa Cruz"]
+    end
+
+    it "adds institutions by name" do
+      expect {
+        described_class.import(names, action_page)
+      }.to change(action_page.institutions, :count).by(names.count)
+    end
+
+    context "when a page has existing institutions" do
+      before { action_page.institutions << institution }
+
+      it "does not remove existing institutions from the action" do
+        expect {
+          described_class.import(names << institution.name, action_page)
+        }.to change(action_page.institutions, :count).by(names.count + 1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Check that the action creates a delayed job
* Check that the job, once run, calls `Institution.import`
* Move assertion of the behavior of `Institution.import` into the model tests

Questions:
* In the import action, if some rows are valid and some rows are not, should we import the valid rows?
* In the case of a successful import, should we flash success?
* Currently, `Institution.import` creates duplicate `ActionInstitution`s. Seems like it shouldn't, right?
* Should Institution <-> ActionPage be a `has_and_belongs_to_many`?