### PR TITLE
Preserve bashslashes in phone number pattern

### DIFF
--- a/vendor/assets/javascripts/congress-forms.js
+++ b/vendor/assets/javascripts/congress-forms.js
@@ -454,7 +454,7 @@
           name='$PHONE' \
           class='form-control bfh-phone' \
           data-format='ddd-ddd-dddd' \
-          pattern='^((5\d[123467890])|(5[123467890]\d)|([2346789]\d\d))-\d\d\d-\d\d\d\d$' \
+          pattern='^((5\\d[123467890])|(5[123467890]\\d)|([2346789]\\d\\d))-\\d\\d\\d-\\d\\d\\d\\d$' \
           title='Must be a valid US phone number entered in 555-555-5555 format' \
           required='required'\
         >")


### PR DESCRIPTION
Fixes redmine 16678. When we switched from using a template for phone number fields to creating them with js, the regex pattern was altered.