### PR TITLE
Disable csrf protection on a few actions

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,6 +2,8 @@ class RegistrationsController < Devise::RegistrationsController
   invisible_captcha only: :create
   after_filter :set_create_notice, only: :create
 
+  skip_before_filter :verify_authenticity_token, only: [:create]
+
   # POST /resource
   def create
     super do |resource|

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,5 @@
 class RegistrationsController < Devise::RegistrationsController
-  invisible_captcha only: :create
+  # invisible_captcha only: :create
   after_filter :set_create_notice, only: :create
 
   skip_before_filter :verify_authenticity_token, only: [:create]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,8 +2,6 @@ class SessionsController < Devise::SessionsController
   after_filter :set_logged_in, only: :create
   before_filter :unset_logged_in, only: :destroy
 
-  skip_before_filter :verify_authenticity_token, only: [:create]
-
   def set_logged_in
     if (user_signed_in?)
       # Sets a "permanent" cookie (which expires in 20 years from now).
@@ -39,5 +37,9 @@ class SessionsController < Devise::SessionsController
       # Should never end up here
       redirect_to "/", flash: { notice: "You need to be logged in to reset your password!" }
     end
+  end
+
+  def protect_against_forgery?
+    action_name != "create"
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,8 @@ class SessionsController < Devise::SessionsController
   after_filter :set_logged_in, only: :create
   before_filter :unset_logged_in, only: :destroy
 
+  skip_before_filter :verify_authenticity_token, only: [:create]
+
   def set_logged_in
     if (user_signed_in?)
       # Sets a "permanent" cookie (which expires in 20 years from now).

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,5 +1,7 @@
 require "civicrm"
 class SubscriptionsController < ApplicationController
+  skip_before_filter :verify_authenticity_token
+
   def create
     email = params[:subscription][:email]
     if EmailValidator.valid?(email)

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -9,7 +9,8 @@ class ToolsController < ApplicationController
   before_filter :create_partner_subscription, only: [:email, :call, :petition, :message_congress]
   after_filter :deliver_thanks_message, only: [:email, :call, :petition, :message_congress]
   skip_after_filter :deliver_thanks_message, if: :signature_has_errors
-  skip_before_filter :verify_authenticity_token, only: :petition
+
+  skip_before_filter :verify_authenticity_token
 
   def call
     ahoy.track "Action",


### PR DESCRIPTION
Session state, which is now stored on the back end, under some circumstances is getting shared between users due to caching. I'm temporarily disabling some controller features until I can push a branch that allows us to switch away from request caching with Fastly.