### PR TITLE
Use cookie_store for sessions

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Actioncenter::Application.config.session_store :active_record_store, key: '_actioncenter_session'
+Actioncenter::Application.config.session_store :cookie_store, key: '_actioncenter_session'

--- a/docker/crontab
+++ b/docker/crontab
@@ -1,4 +1,4 @@
 0 * * * * root su -s/bin/bash www-data -c '. /var/www/.profile && cd /opt/actioncenter && bundle exec rake signatures:deduplicate' >>/proc/1/fd/1 2>&1
 0 0 * * * root su -s/bin/bash www-data -c '. /var/www/.profile && cd /opt/actioncenter && bundle exec rake congress:update'        >>/proc/1/fd/1 2>&1
-0 0 * * * root su -s/bin/bash www-data -c '. /var/www/.profile && cd /opt/actioncenter && bundle exec rake db:sessions:trim'        >>/proc/1/fd/1 2>&1
+# 0 0 * * * root su -s/bin/bash www-data -c '. /var/www/.profile && cd /opt/actioncenter && bundle exec rake db:sessions:trim'        >>/proc/1/fd/1 2>&1
 


### PR DESCRIPTION
Session state, which is now stored on the back end, under some circumstances is getting shared between users due to caching. I'm temporarily reverting session storage to use cookies until I can push a branch that allows us to switch away from request caching with Fastly.