### PR TITLE
Don't pass referrer header to twitter on action share link

### DIFF
--- a/app/views/tools/_call.html.erb
+++ b/app/views/tools/_call.html.erb
@@ -102,28 +102,7 @@
             </div>
           </div>
 
-          <div class="vertical-share">
-            <p>Once you're done, help spread the word:</p>
-            <a href="<%= twitter_share_url(@actionPage) -%>" class="twitter twitter-button">
-              <div class="sicon" id="stwit"></div>
-              <div class="share-label">Share on Twitter</div>
-            </a>
-            <a href="<%= facebook_share_url(@actionPage) -%>" class="facebook facebook-button">
-              <div class="sicon" id="sfb"></div>
-              <div class="share-label">Share on Facebook</div>
-            </a>
-            <a href="<%= google_share_url(@actionPage) -%>" class="google google-button">
-              <div class="sicon" id="sgplus"></div>
-              <div class="share-label">Share on Google+</div>
-            </a>
-          </div>
-
-          <p style="text-align: center;">
-            <% if current_user.nil? %>
-            <br />
-            <strong><a href="/register">Sign up</a> for an EFF Action account and save your information for next time.</strong>
-            <% end %>
-          </p>
+          <%= render 'tools/share' -%>
         </div>
 
       </div>

--- a/app/views/tools/_congress_message.html.erb
+++ b/app/views/tools/_congress_message.html.erb
@@ -56,7 +56,15 @@
               "bioguide-ids": bioguide_ids(@congress_message_campaign, @target_bioguide_ids),
               "topic-category": @topic_category.to_json
             }) %>
-      <%= render "tools/share" -%>
+
+      <div class="thank-you" style="display: none;">
+        <div class="alert alert-success">Thank you for the email</div>
+      </div>
+
+      <div class="email-tool-success-share" style="display: none;">
+        <%= render "tools/share" -%>
+      </div>
+
     </div>
     <div class="tool-body without-js">
       <h4><strong>Our email tool requires javascript.</strong></h4>

--- a/app/views/tools/_email.html.erb
+++ b/app/views/tools/_email.html.erb
@@ -59,7 +59,13 @@
 
         <div id='email_target_text'><%= render 'tools/email_target_text' %></div>
 
-        <%= render 'tools/share' -%>
+        <div class="thank-you" style="display: none;">
+          <div class="alert alert-success">Thank you for the email</div>
+        </div>
+
+        <div class="email-tool-success-share" style="display: none;">
+          <%= render 'tools/share' -%>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/tools/_petition.html.erb
+++ b/app/views/tools/_petition.html.erb
@@ -35,30 +35,7 @@
       <% end -%>
 
         <div class='signed'>
-          <div class='vertical-share'>
-            <b class='small'>Now help spread the word:</b>
-            <a href='<%= twitter_share_url(@actionPage) -%>' class='twitter twitter-button'>
-              <div class="sicon" id="stwit"></div>
-              <div class="share-label">Share on Twitter</div>
-            </a>
-            <a href='<%= facebook_share_url(@actionPage) -%>' class='facebook facebook-button'>
-              <div class="sicon" id="sfb"></div>
-              <div class="share-label">Share on Facebook</div>
-            </a>
-            <a href='<%= google_share_url(@actionPage) -%>' class='google google-button'>
-              <div class="sicon" id="sgplus"></div>
-              <div class="share-label">Share on Google+</div>
-            </a>
-          </div>
-          <b class='small'>
-            Have you
-            <a href='https://supporters.eff.org/donate' target='blank'>donated to EFF</a>
-            lately?
-            <% if !current_user %>
-            <br />
-            <strong><a href="/register">Sign up</a> for an EFF Action account and save your information for next time.</strong>
-            <% end %>
-          </b>
+          <%= render 'tools/share' -%>
         </div>
         <div class='unsigned'>
           <%= form_for @signature, url: '/tools/petition',

--- a/app/views/tools/_share.html.erb
+++ b/app/views/tools/_share.html.erb
@@ -1,6 +1,6 @@
-<div class="vertical-share">
-  <b class="small">Now help spread the word:</b>
-  <a href="<%= twitter_share_url(@actionPage) -%>" class="twitter twitter-button" rel="noreferrer">
+<div class='vertical-share '>
+  <b class='small'>Now help spread the word:</b>
+  <a href='<%= twitter_share_url(@actionPage) -%>' class='twitter twitter-button'>
     <div class="sicon" id="stwit"></div>
     <div class="share-label">Share on Twitter</div>
   </a>

--- a/app/views/tools/_share.html.erb
+++ b/app/views/tools/_share.html.erb
@@ -1,6 +1,6 @@
 <div class='vertical-share '>
   <b class='small'>Now help spread the word:</b>
-  <a href='<%= twitter_share_url(@actionPage) -%>' class='twitter twitter-button'>
+  <a href='<%= twitter_share_url(@actionPage) -%>' class='twitter twitter-button' rel="noreferrer">
     <div class="sicon" id="stwit"></div>
     <div class="share-label">Share on Twitter</div>
   </a>

--- a/app/views/tools/_share.html.erb
+++ b/app/views/tools/_share.html.erb
@@ -1,28 +1,23 @@
-<div class="thank-you" style="display: none;">
-  <div class="alert alert-success">Thank you for the email</div>
-</div>
-<div class="email-tool-success-share" style="display: none;">
-  <div class='vertical-share '>
-    <b class='small'>Now help spread the word:</b>
-    <a href='<%= twitter_share_url(@actionPage) -%>' class='twitter twitter-button'>
-      <div class="sicon" id="stwit"></div>
-      <div class="share-label">Share on Twitter</div>
-    </a>
-    <a href='<%= facebook_share_url(@actionPage) -%>' class='facebook facebook-button'>
-      <div class="sicon" id="sfb"></div>
-      <div class="share-label">Share on Facebook</div>
-    </a>
-    <a href='<%= google_share_url(@actionPage) -%>' class='google google-button'>
-      <div class="sicon" id="sgplus"></div>
-      <div class="share-label">Share on Google+</div>
-    </a>
+<div class='vertical-share '>
+  <b class='small'>Now help spread the word:</b>
+  <a href='<%= twitter_share_url(@actionPage) -%>' class='twitter twitter-button'>
+    <div class="sicon" id="stwit"></div>
+    <div class="share-label">Share on Twitter</div>
+  </a>
+  <a href='<%= facebook_share_url(@actionPage) -%>' class='facebook facebook-button'>
+    <div class="sicon" id="sfb"></div>
+    <div class="share-label">Share on Facebook</div>
+  </a>
+  <a href='<%= google_share_url(@actionPage) -%>' class='google google-button'>
+    <div class="sicon" id="sgplus"></div>
+    <div class="share-label">Share on Google+</div>
+  </a>
 
-  </div>
-  <p class='small donate'>
-    Have you <a href='https://supporters.eff.org/donate' target='blank'>donated to EFF</a> lately?
-    <% if !current_user %>
-    <br />
-    <strong><a href="/register">Sign up</a> for an EFF Action account and save your information for next time.</strong>
-    <% end %>
-  </p>
 </div>
+<p class='small donate'>
+  Have you <a href='https://supporters.eff.org/donate' target='blank'>donated to EFF</a> lately?
+  <% if !current_user %>
+  <br />
+  <strong><a href="/register">Sign up</a> for an EFF Action account and save your information for next time.</strong>
+  <% end %>
+</p>

--- a/app/views/tools/_share.html.erb
+++ b/app/views/tools/_share.html.erb
@@ -1,21 +1,21 @@
-<div class='vertical-share '>
-  <b class='small'>Now help spread the word:</b>
-  <a href='<%= twitter_share_url(@actionPage) -%>' class='twitter twitter-button' rel="noreferrer">
+<div class="vertical-share">
+  <b class="small">Now help spread the word:</b>
+  <a href="<%= twitter_share_url(@actionPage) -%>" class="twitter twitter-button" rel="noreferrer">
     <div class="sicon" id="stwit"></div>
     <div class="share-label">Share on Twitter</div>
   </a>
-  <a href='<%= facebook_share_url(@actionPage) -%>' class='facebook facebook-button'>
+  <a href="<%= facebook_share_url(@actionPage) -%>" class="facebook facebook-button">
     <div class="sicon" id="sfb"></div>
     <div class="share-label">Share on Facebook</div>
   </a>
-  <a href='<%= google_share_url(@actionPage) -%>' class='google google-button'>
+  <a href="<%= google_share_url(@actionPage) -%>" class="google google-button">
     <div class="sicon" id="sgplus"></div>
     <div class="share-label">Share on Google+</div>
   </a>
 
 </div>
-<p class='small donate'>
-  Have you <a href='https://supporters.eff.org/donate' target='blank'>donated to EFF</a> lately?
+<p class="small donate">
+  Have you <a href="https://supporters.eff.org/donate" target="blank">donated to EFF</a> lately?
   <% if !current_user %>
   <br />
   <strong><a href="/register">Sign up</a> for an EFF Action account and save your information for next time.</strong>


### PR DESCRIPTION
The Action Center embed url can be super huge. In general, we should pass a link to a stylesheet instead of putting all the styles in the url, but this will help prevent HTTP 431 from Twitter when the url gets big.

This PR also dried up some views. Call actions previously didn't have a donate link, while all the other actions did. This adds a donate link to call actions.