### PR TITLE
When we can't do verify_authenticity_token, verify origin header instead

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
   include ApplicationHelper
+  include RequestOriginValidation
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/concerns/request_origin_validation.rb
+++ b/app/controllers/concerns/request_origin_validation.rb
@@ -3,7 +3,7 @@ module RequestOriginValidation
     return if request.get? || request.head?
 
     # Accept blank origin headers because some user agents don't send it.
-    origin = request.headers['origin']
+    origin = request.headers["origin"]
     unless origin.nil? || origin == request.base_url
       logger.warn "HTTP Origin header (#{origin.inspect}) didn't match request.base_url (#{request.base_url})"
       raise ActionController::InvalidCrossOriginRequest

--- a/app/controllers/concerns/request_origin_validation.rb
+++ b/app/controllers/concerns/request_origin_validation.rb
@@ -1,0 +1,12 @@
+module RequestOriginValidation
+  def verify_request_origin
+    return if request.get? || request.head?
+
+    # Accept blank origin headers because some user agents don't send it.
+    origin = request.headers['origin']
+    unless origin.nil? || origin == request.base_url
+      logger.warn "HTTP Origin header (#{origin.inspect}) didn't match request.base_url (#{request.base_url})"
+      raise ActionController::InvalidCrossOriginRequest
+    end
+  end
+end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -2,6 +2,7 @@ require "civicrm"
 class SubscriptionsController < ApplicationController
   # See https://github.com/EFForg/action-center-platform/wiki/Deployment-Notes#csrf-protection
   skip_before_filter :verify_authenticity_token
+  before_filter :verify_request_origin
 
   def create
     email = params[:subscription][:email]

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -12,6 +12,7 @@ class ToolsController < ApplicationController
 
   # See https://github.com/EFForg/action-center-platform/wiki/Deployment-Notes#csrf-protection
   skip_before_filter :verify_authenticity_token
+  before_filter :verify_request_origin
 
   def call
     ahoy.track "Action",

--- a/spec/controllers/concerns/request_origin_validation_spec.rb
+++ b/spec/controllers/concerns/request_origin_validation_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe RequestOriginValidation do
         OpenStruct.new(
           headers: { "origin" => "https://example.com" },
           base_url: "https://example.com",
-          :"get?" => false,
-          :"head?" => false
+          "get?": false,
+          "head?": false
         ).tap do |request|
           allow(controller).to receive(:request){ request }
         end
@@ -39,8 +39,8 @@ RSpec.describe RequestOriginValidation do
         OpenStruct.new(
           headers: { "origin" => "https://example.org" },
           base_url: "https://example.net",
-          :"get?" => false,
-          :"head?" => false
+          "get?": false,
+          "head?": false
         ).tap do |request|
           allow(controller).to receive(:request){ request }
         end

--- a/spec/controllers/concerns/request_origin_validation_spec.rb
+++ b/spec/controllers/concerns/request_origin_validation_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe RequestOriginValidation do
+  controller_class = Class.new(ActionController::Base) do
+    include RequestOriginValidation
+  end
+
+  let(:controller){ controller_class.new }
+
+  describe "#verify_request_origin" do
+    context "same origin request" do
+      let!(:request) do
+        OpenStruct.new(
+          headers: { "origin" => "https://example.com" },
+          base_url: "https://example.com",
+          :"get?" => false,
+          :"head?" => false
+        ).tap do |request|
+          allow(controller).to receive(:request){ request }
+        end
+      end
+
+      it "should not raise an error for any method" do
+        request["get?"] = true
+        expect{ controller.verify_request_origin }.not_to raise_error
+        request["get?"] = false
+
+        request["head?"] = true
+        expect{ controller.verify_request_origin }.not_to raise_error
+        request["head?"] = false
+
+        request["post?"] = true
+        expect{ controller.verify_request_origin }.not_to raise_error
+      end
+    end
+
+    context "cross origin request" do
+      let!(:request) do
+        OpenStruct.new(
+          headers: { "origin" => "https://example.org" },
+          base_url: "https://example.net",
+          :"get?" => false,
+          :"head?" => false
+        ).tap do |request|
+          allow(controller).to receive(:request){ request }
+        end
+      end
+
+      it "should not raise an error for GET or HEAD methods" do
+        request["get?"] = true
+        expect{ controller.verify_request_origin }.not_to raise_error
+        request["get?"] = false
+
+        request["head?"] = true
+        expect{ controller.verify_request_origin }.not_to raise_error
+        request["head?"] = false
+      end
+
+      it "should raise an error for POST requests" do
+        request["post?"] = true
+        expect{ controller.verify_request_origin }.
+          to raise_error(ActionController::InvalidCrossOriginRequest)
+      end
+    end
+  end
+end


### PR DESCRIPTION
As recommended in the [CSRF cheat sheet](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Verifying_Same_Origin_with_Standard_Headers). Follow up to #396.