### PR TITLE
Use supporters contact preferences form with checksum

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,8 +1,10 @@
 require "civicrm"
 class SubscriptionsController < ApplicationController
   # See https://github.com/EFForg/action-center-platform/wiki/Deployment-Notes#csrf-protection
-  skip_before_filter :verify_authenticity_token
-  before_filter :verify_request_origin
+  skip_before_filter :verify_authenticity_token, only: :create
+  before_filter :verify_request_origin, only: :create
+
+  before_filter :authenticate_user!, only: :edit
 
   def create
     email = params[:subscription][:email]
@@ -15,5 +17,9 @@ class SubscriptionsController < ApplicationController
     else
       render text: "fail, bad email", status: 400
     end
+  end
+
+  def edit
+    redirect_to current_user.manage_subscription_url!
   end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -20,6 +20,12 @@ class SubscriptionsController < ApplicationController
   end
 
   def edit
-    redirect_to current_user.manage_subscription_url!
+    civicrm_url = current_user.manage_subscription_url!
+    if civicrm_url
+      redirect_to civicrm_url
+    else
+      flash.now[:error] = "We're unable to generate a subscription management URL. Please try again later."
+      redirect_to "/account"
+    end
   end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -24,7 +24,7 @@ class SubscriptionsController < ApplicationController
     if civicrm_url
       redirect_to civicrm_url
     else
-      flash.now[:error] = "We're unable to generate a subscription management URL. Please try again later."
+      flash.now[:error] = I18n.t "subscriptions.edit_error"
       redirect_to "/account"
     end
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -180,7 +180,7 @@
       <% if current_user.contact_id! -%>
         <p>Click below to change your EFF newsletter subscriptions.</p>
         <%= link_to "Edit subscriptions",
-          "#{Rails.application.secrets.supporters['host']}/update-preferences?id=#{current_user.contact_id}",
+          edit_subscription_path(current_user),
           :class => 'btn btn-sm btn-red-outline edit-settings' -%>
       <% else -%>
         <form action="https://supporters.eff.org/" method="post" id="eff-supporters-library-account-form" accept-charset="UTF-8" _lpchecked="1">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,3 +74,5 @@ en:
       institution: Select an institution
       affiliation_type: How are you affilliated with this institution?
   privacy_notice: EFF uses the information you provide to defend digital rights, including improving our campaigns and sharing information about them, and to contact decisionmakers on your behalf. For details, see our privacy policy at eff.org/policy.
+  subscriptions:
+    edit_error: We're unable to generate a subscription management URL. Please try again later.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,7 @@ Actioncenter::Application.routes.draw do
     end
   end
 
-  resources :subscriptions, only: :create
+  resources :subscriptions, only: [:create, :edit]
 
   resources :partners, only: [:show, :edit, :update] do
     member do

--- a/lib/civicrm.rb
+++ b/lib/civicrm.rb
@@ -30,6 +30,13 @@ module CiviCRM
         )
       end
     end
+
+    def manage_subscription_url!
+      "#{Rails.application.secrets.supporters['host']}/update-your-preferences?" + {
+        cid1: contact_id,
+        cs: CiviCRM::get_checksum(contact_id)
+      }.to_param
+    end
   end
 
   def self.skip_crm?
@@ -101,6 +108,16 @@ module CiviCRM
       method: "find_contact_by_email",
       data: params.slice(:email).merge(method: "find_contact_by_email").to_json
     )
+  end
+
+  def self.get_checksum(contact_id)
+    return nil if skip_crm?
+    # Valid for 24 hours
+    res = post base_params.merge(
+      method: "generate_checksum",
+      data: contact_id
+    )
+    res["checksum"]
   end
 
   def self.base_params

--- a/lib/civicrm.rb
+++ b/lib/civicrm.rb
@@ -32,9 +32,11 @@ module CiviCRM
     end
 
     def manage_subscription_url!
+      checksum = CiviCRM::get_checksum(contact_id)
+      return nil unless checksum
       "#{Rails.application.secrets.supporters['host']}/update-your-preferences?" + {
         cid1: contact_id,
-        cs: CiviCRM::get_checksum(contact_id)
+        cs: checksum
       }.to_param
     end
   end
@@ -117,7 +119,7 @@ module CiviCRM
       method: "generate_checksum",
       data: contact_id
     )
-    res["checksum"]
+    res && res["checksum"]
   end
 
   def self.base_params

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe SubscriptionsController, type: :controller do
-  before(:each) do
+  before do
     stub_civicrm
   end
 
@@ -38,5 +38,19 @@ RSpec.describe SubscriptionsController, type: :controller do
       sign_in FactoryGirl.create(:user)
       expect(subject).to redirect_to(/#{Rails.application.secrets.supporters["host"]}/)
     end
+
+    describe "without a successful connection to civicrm" do
+      before do
+        stub_request(:post, CiviCRM::supporters_api_url).
+          and_return(status: 400, body: "{}", headers: {})
+      end
+
+      it "fails gracefully" do
+        sign_in FactoryGirl.create(:user)
+        expect(subject).to redirect_to("/account")
+        expect(flash[:error]).to be_present
+      end
+    end
   end
+
 end

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -1,30 +1,42 @@
 require "rails_helper"
 
 RSpec.describe SubscriptionsController, type: :controller do
-  let(:valid_attributes) do
-    {
-      subscription: {
-        "email" => "johnsmith@eff.org",
-        "mailing_list" => "effector"
-      },
-      format: :json
-    }
-  end
-
   before(:each) do
     stub_civicrm
   end
 
-  it "can accept an email" do
-    post :create, valid_attributes
+  describe "#create" do
+    let(:valid_attributes) do
+      {
+        subscription: {
+          "email" => "johnsmith@eff.org",
+          "mailing_list" => "effector"
+        },
+        format: :json
+      }
+    end
 
-    expect(response.code).to eq "200"
+    it "can accept an email" do
+      post :create, valid_attributes
+
+      expect(response.code).to eq "200"
+    end
+
+    it "can reject a spammy looking email" do
+      invalid_email = valid_attributes.merge(subscription: { email: "meh" })
+      post :create, invalid_email
+
+      expect(response.code).to eq "400"
+    end
   end
 
-  it "can reject a spammy looking email" do
-    invalid_email = valid_attributes.merge(subscription: { email: "meh" })
-    post :create, invalid_email
+  describe "#edit" do
+    let(:subscription) { FactoryGirl.create(:subscription) }
+    subject { get :edit, { id: subscription } }
 
-    expect(response.code).to eq "400"
+    it "redirects to supporters" do
+      sign_in FactoryGirl.create(:user)
+      expect(subject).to redirect_to(/#{Rails.application.secrets.supporters["host"]}/)
+    end
   end
 end

--- a/spec/lib/civicrm_spec.rb
+++ b/spec/lib/civicrm_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe CiviCRM do
+  before do
+    stub_civicrm
+  end
+
+  describe "self.get_checksum" do
+    it "calls the civicrm API with method 'generate_checksum'" do
+      CiviCRM::get_checksum(123)
+      assert_requested :post, CiviCRM::supporters_api_url, body: /generate_checksum/
+    end
+  end
+end
+
+shared_examples_for "civicrm_user_methods" do
+  subject { described_class.new }
+
+  describe ".manage_subscription_url!" do
+    it "encodes a checksum" do
+      allow(CiviCRM).to receive(:get_checksum).and_return("xyz")
+      expect(subject.manage_subscription_url!).to include("cs=xyz")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require 'lib/civicrm_spec'
 
 describe User do
   let(:attr) { FactoryGirl.attributes_for :user }
@@ -7,6 +8,8 @@ describe User do
   before(:each) do
     stub_civicrm
   end
+
+  it_behaves_like "civicrm_user_methods"
 
   it "creates a new instance given a valid attributes" do
     User.create!(attr)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require 'lib/civicrm_spec'
+require "lib/civicrm_spec"
 
 describe User do
   let(:attr) { FactoryGirl.attributes_for :user }

--- a/spec/support/service_helpers.rb
+++ b/spec/support/service_helpers.rb
@@ -3,6 +3,10 @@ module ServiceHelpers
     Rails.application.secrets.supporters["host"] = "https://civicrm.test"
     stub_request(:post, CiviCRM::supporters_api_url).
       and_return(status: 200, body: "{}", headers: {})
+
+    stub_request(:post, CiviCRM::supporters_api_url).
+      with(body: /generate_checksum/).
+      and_return(status: 200, body: { checksum: "xyz" }.to_json, headers: {})
   end
 end
 

--- a/spec/support/service_helpers.rb
+++ b/spec/support/service_helpers.rb
@@ -2,7 +2,7 @@ module ServiceHelpers
   def stub_civicrm
     Rails.application.secrets.supporters["host"] = "https://civicrm.test"
     stub_request(:post, CiviCRM::supporters_api_url).
-      to_return(status: 200, body: "{}", headers: {})
+      and_return(status: 200, body: "{}", headers: {})
   end
 end
 


### PR DESCRIPTION
Resolves #404 

Redirects users to a form managed by supporters.eff.org/civicrm, which requires a contact id and checksum to authenticate the user.

Marked WIP because this shouldn't be deployed until the corresponding checksum endpoint is live on supporters.