### PR TITLE
Migrate to aws-sdk v2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,11 +72,14 @@ GEM
       builder
       mime-types
       xml-simple
-    aws-sdk (1.66.0)
-      aws-sdk-v1 (= 1.66.0)
-    aws-sdk-v1 (1.66.0)
-      json (~> 1.4)
-      nokogiri (>= 1.4.4)
+    aws-sdk (2.11.27)
+      aws-sdk-resources (= 2.11.27)
+    aws-sdk-core (2.11.27)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.11.27)
+      aws-sdk-core (= 2.11.27)
+    aws-sigv4 (1.0.2)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -105,8 +108,6 @@ GEM
     chronic (0.10.2)
     climate_control (0.2.0)
     cliver (0.3.2)
-    cocaine (0.5.8)
-      climate_control (>= 0.0.3, < 1.0)
     cocoon (1.2.9)
     coderay (1.1.1)
     coffee-script-source (1.10.0)
@@ -204,7 +205,7 @@ GEM
       domain_name (~> 0.5)
     http_accept_language (2.0.5)
     http_parser.rb (0.6.0)
-    i18n (0.9.1)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     invisible_captcha (0.10.0)
       rails (>= 3.2.0)
@@ -212,6 +213,7 @@ GEM
     jbuilder (1.5.3)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2.0)
+    jmespath (1.3.1)
     jquery-fileupload-rails (0.4.6)
       actionpack (>= 3.1)
       railties (>= 3.1)
@@ -234,7 +236,7 @@ GEM
     mimemagic (0.3.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
-    minitest (5.10.3)
+    minitest (5.11.3)
     multi_json (1.12.2)
     multi_test (0.1.2)
     multipart-post (2.0.0)
@@ -245,12 +247,12 @@ GEM
       nokogiri
     oauth (0.5.1)
     orm_adapter (0.5.0)
-    paperclip (5.2.1)
+    paperclip (5.3.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
-      cocaine (~> 0.5.5)
       mime-types
       mimemagic (~> 0.3.0)
+      terrapin (~> 0.6.0)
     pg (0.15.1)
     poltergeist (1.10.0)
       capybara (~> 2.1)
@@ -413,10 +415,12 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    terrapin (0.6.0)
+      climate_control (>= 0.0.3, < 1.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (1.4.1)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
@@ -450,7 +454,7 @@ PLATFORMS
 DEPENDENCIES
   acts_as_paranoid!
   ahoy_matey
-  aws-sdk (< 2.0)
+  aws-sdk (~> 2.3)
   better_errors
   binding_of_caller
   bourbon
@@ -533,4 +537,4 @@ DEPENDENCIES
   will_paginate (~> 3.0)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -59,9 +59,9 @@ class SourceFile < ActiveRecord::Base
   def s3_object
     Rails.logger.debug "Trying to get S3 object."
     s3 = Aws::S3::Resource.new(
-      :access_key_id => S3CorsFileupload::Config.access_key_id,
-      :secret_access_key => S3CorsFileupload::Config.secret_access_key,
-      :region => Rails.application.secrets.amazon_region
+      access_key_id: S3CorsFileupload::Config.access_key_id,
+      secret_access_key: S3CorsFileupload::Config.secret_access_key,
+      region: Rails.application.secrets.amazon_region
     )
     @s3_object = s3.bucket(Rails.application.secrets.amazon_bucket).object(key)
   rescue
@@ -72,9 +72,9 @@ class SourceFile < ActiveRecord::Base
   def self.open_aws
     unless @aws_connected
       Aws::S3::Base.establish_connection!(
-        :access_key_id => S3CorsFileupload::Config.access_key_id,
-        :secret_access_key => S3CorsFileupload::Config.secret_access_key,
-        :region => Rails.application.secrets.amazon_region
+        access_key_id: S3CorsFileupload::Config.access_key_id,
+        secret_access_key: S3CorsFileupload::Config.secret_access_key,
+        region: Rails.application.secrets.amazon_region
       )
     end
     @aws_connected ||= Aws::S3::Base.connected?

--- a/lib/amazon_credentials.rb
+++ b/lib/amazon_credentials.rb
@@ -2,20 +2,21 @@ module AmazonCredentials
   def amazon_credentials
     bucket_url_options = {}
     bucket_url_options = {
-      :s3_host_alias => Rails.application.secrets.amazon_bucket_url,
-      :url => ':s3_alias_url',
-      :path => '/:class/:attachment/:id_partition/:style/:filename'
+      s3_host_alias: Rails.application.secrets.amazon_bucket_url,
+      url: ':s3_alias_url',
+      path: '/:class/:attachment/:id_partition/:style/:filename'
     } unless Rails.application.secrets.amazon_bucket_url.nil?
 
     {
-      :storage => Rails.application.secrets.storage.to_sym,
-      :s3_credentials => {
+      storage: Rails.application.secrets.storage.to_sym,
+      s3_credentials: {
         bucket: Rails.application.secrets.amazon_bucket,
         access_key_id: Rails.application.secrets.amazon_access_key_id,
         secret_access_key: Rails.application.secrets.amazon_secret_access_key
       },
-      :s3_host_name => build_s3_host_name,
-      :s3_protocol => 'https'
+      region: Rails.application.secrets.amazon_region,
+      s3_host_name: build_s3_host_name,
+      s3_protocol: 'https'
     }.merge(bucket_url_options)
   end
 


### PR DESCRIPTION
I believe that this PR represents all necessary changes to upgrade AWS-SDK to v2.  However, I can't upload files from my local environment, so I can't test that it works.  Maybe my secrets are wrong?  

Anyway, the action returns success and does not return "Attempt to get S3 object failed.", so I'm somewhat confident.