### PR TITLE
Don't check origin header on e-mail action

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -12,7 +12,7 @@ class ToolsController < ApplicationController
 
   # See https://github.com/EFForg/action-center-platform/wiki/Deployment-Notes#csrf-protection
   skip_before_filter :verify_authenticity_token
-  before_filter :verify_request_origin
+  before_filter :verify_request_origin, except: :email
 
   def call
     ahoy.track "Action",


### PR DESCRIPTION
This is throwing a 422 on a currently-running action. Pushing this as a quick fix while I look into the header mismatch.