### PR TITLE
Fix password reset

### DIFF
--- a/config/response-headers.yml
+++ b/config/response-headers.yml
@@ -33,6 +33,8 @@ devise/confirmations:
 
 devise/passwords:
   new: *dont_cache
+  edit: *dont_cache
+  update: *dont_cache
 
 devise/unlock:
   new: *dont_cache


### PR DESCRIPTION
https://redmine.eff.org/issues/17730
Shahid couldn't reset his password; when he tried, it raised a 500.  I got the same result.  Steps to replicate:

1. go to https://act.eff.org/login
2. click 'forgot your password'
3. enter your email and click 'send me reset password instructions'
4. receive email; click link. This takes you to a page like "https://act.eff.org/password/edit?reset_password_token=something"
5.enter your new password twice
6. click "change my password"
7. oh noes: "500 Internal Server Error If you are the administrator of this website, then please read this web application's log file and/or the web server's log file to find out what went wrong."

When I looked at the logs, I saw that PUT /passwords was returning 422 with`Can't verify CSRF token authenticity`.  The params did include AuthenticityToken.  Stack Overflow suggested that it might be a cached token.  I looked into how we cache with Fastly, and turned off caching for password reset endpoints.

I'm not sure this will work!  I'll talk to Vivian about it.