### PR TITLE
Set cookie on password/edit to avoid CSRF error

### DIFF
--- a/varnish.vcl
+++ b/varnish.vcl
@@ -20,7 +20,7 @@ sub vcl_recv {
 }
 
 sub vcl_fetch {
-  if (req.http.cookie !~ "logged_in" && req.url !~ "^/(login)|(register)|(confirmation/new)|(unlock/new)|(password/new)|(ahoy/)") {
+  if (req.http.cookie !~ "logged_in" && req.url !~ "^/(login)|(register)|(confirmation/new)|(unlock/new)|(password/new)|(password/edit)|(ahoy/)") {
       unset beresp.http.Set-Cookie;
   }
 


### PR DESCRIPTION
This is for Redmine #17730

We need to prevent Varnish from unsetting the cookie that matches the CSRF token for the password reset form at `/password/edit`.