### PR TITLE
Mailing list honeypot captcha

### DIFF
--- a/app/assets/javascripts/application/strings.js
+++ b/app/assets/javascripts/application/strings.js
@@ -1,8 +1,8 @@
 window.App = window.App || {};
 
 window.App.Strings = {
-  invalidEmailSubmission: "<p>Bad news, something went wrong with your email address.  Please check it for typos and try again.</p>",
   successfulEmailSubmission: "<p>Thanks for subscribing, you're awesome!<p></p>Check your email for a confirmation link.</p>",
+  failedEmailSubmission: "<p>We're sorry, something went wrong with your subscription. Please try again later.</p>",
   addressLookupFailed: "We were unable to find a zip+4 for the address you entered.  Make sure you *only* entered your street address (without your city and state).  Please check and try again.",
   districtLookupFailed: "We were unable to find a congressional district for the address you entered.  Make sure you *only* entered your street address (without your city and state).  Please check and try again."
 };

--- a/app/assets/javascripts/application/strings.js
+++ b/app/assets/javascripts/application/strings.js
@@ -1,8 +1,8 @@
 window.App = window.App || {};
 
 window.App.Strings = {
-  successfulEmailSubmission: "<p>Thanks for subscribing, you're awesome!<p></p>Check your email for a confirmation link.</p>",
-  failedEmailSubmission: "<p>We're sorry, something went wrong with your subscription. Please try again later.</p>",
+  successfulEmailSubmission: "Thanks for subscribing, you're awesome! Check your email for a confirmation link.",
+  failedEmailSubmission: "We're sorry, something went wrong with your subscription. Please try again later.",
   addressLookupFailed: "We were unable to find a zip+4 for the address you entered.  Make sure you *only* entered your street address (without your city and state).  Please check and try again.",
   districtLookupFailed: "We were unable to find a congressional district for the address you entered.  Make sure you *only* entered your street address (without your city and state).  Please check and try again."
 };

--- a/app/assets/javascripts/application/welcome.js
+++ b/app/assets/javascripts/application/welcome.js
@@ -47,12 +47,14 @@ $(document).ready(function() {
     },
     complete: function(xhr, data, status) {
       $('.progress-striped').hide();
+      var message;
       if (status === "success")
-        return $(App.Strings.successfulEmailSubmission).insertAfter(this);
+        message = App.Strings.successfulEmailSubmission;
       else if (data.responseJSON.message)
-        return $(data.responseJSON.message).insertAfter(this);
+        message = data.responseJSON.message;
       else
-        return $(App.Strings.failedEmailSubmission).insertAfter(this);
+        message = App.Strings.failedEmailSubmission;
+      return $("<p>").text(message).insertAfter(this);
     }
   };
 

--- a/app/assets/javascripts/application/welcome.js
+++ b/app/assets/javascripts/application/welcome.js
@@ -47,10 +47,12 @@ $(document).ready(function() {
     },
     complete: function(xhr, data, status) {
       $('.progress-striped').hide();
-      if(status === "success")
+      if (status === "success")
         return $(App.Strings.successfulEmailSubmission).insertAfter(this);
+      else if (data.responseJSON.message)
+        return $(data.responseJSON.message).insertAfter(this);
       else
-        return $(App.Strings.invalidEmailSubmission).insertAfter(this);
+        return $(App.Strings.failedEmailSubmission).insertAfter(this);
     }
   };
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -4,6 +4,7 @@ class SubscriptionsController < ApplicationController
   skip_before_filter :verify_authenticity_token, only: :create
   before_filter :verify_request_origin, only: :create
 
+  invisible_captcha only: :create
   before_filter :authenticate_user!, only: :edit
 
   def create

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -5,6 +5,10 @@ require "json"
 class ToolsController < ApplicationController
   before_filter :set_user
   before_filter :set_action_page
+
+  # Put an invisible captcha on forms are easy to submit programmatically and
+  # create email subscriptions.
+  invisible_captcha only: [:email, :petition]
   before_filter :create_newsletter_subscription, only: [:email, :call]
   before_filter :create_partner_subscription, only: [:email, :call, :petition, :message_congress]
   after_filter :deliver_thanks_message, only: [:email, :call, :petition, :message_congress]

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -2,6 +2,7 @@
   <div class="email-signup center-block">
     <%= form_for :subscription, url: subscriptions_path, remote: true,
                   html: { id: "subscription-form", class: "form-inline", role: "form" } do |f| -%>
+      <%= f.invisible_captcha %>
       <%= token_tag(form_authenticity_token) %>
       <%= f.hidden_field :mailing_list, value: "effector" -%>
       <div class="form-group">

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="email-signup center-block">
     <%= form_for :subscription, url: subscriptions_path, remote: true,
                   html: { id: "subscription-form", class: "form-inline", role: "form" } do |f| -%>
-      <%= f.invisible_captcha %>
+      <%= invisible_captcha %>
       <%= token_tag(form_authenticity_token) %>
       <%= f.hidden_field :mailing_list, value: "effector" -%>
       <div class="form-group">

--- a/app/views/tools/_email.html.erb
+++ b/app/views/tools/_email.html.erb
@@ -16,6 +16,7 @@
       <%= form_tag '/tools/email', method: 'post', target: '_blank' do |f| -%>
         <input type="hidden" name="action_id" value="<%= @actionPage.id %>" />
         <input type="hidden" name="dnt" value="false" />
+        <%= f.invisible_captcha %>
 
         <%= render "/tools/newsletter_signup", email: true, location: true, privacy_notice: true %>
 

--- a/app/views/tools/_email.html.erb
+++ b/app/views/tools/_email.html.erb
@@ -16,7 +16,7 @@
       <%= form_tag '/tools/email', method: 'post', target: '_blank' do |f| -%>
         <input type="hidden" name="action_id" value="<%= @actionPage.id %>" />
         <input type="hidden" name="dnt" value="false" />
-        <%= f.invisible_captcha %>
+        <%= invisible_captcha %>
 
         <%= render "/tools/newsletter_signup", email: true, location: true, privacy_notice: true %>
 

--- a/app/views/tools/_mailing_list.html.erb
+++ b/app/views/tools/_mailing_list.html.erb
@@ -8,7 +8,7 @@
     <div class="tool-body">
       <%= form_for :subscription, url: subscriptions_path, remote: true,
                     html: { id: "subscription-form", class: "", role: "form" } do |f| -%>
-        <%= f.invisible_captcha %>
+        <%= invisible_captcha %>
         <%= token_tag(form_authenticity_token) %>
         <%= f.hidden_field :mailing_list, value: "effector" -%>
         <fieldset>

--- a/app/views/tools/_mailing_list.html.erb
+++ b/app/views/tools/_mailing_list.html.erb
@@ -8,6 +8,7 @@
     <div class="tool-body">
       <%= form_for :subscription, url: subscriptions_path, remote: true,
                     html: { id: "subscription-form", class: "", role: "form" } do |f| -%>
+        <%= f.invisible_captcha %>
         <%= token_tag(form_authenticity_token) %>
         <%= f.hidden_field :mailing_list, value: "effector" -%>
         <fieldset>

--- a/app/views/tools/_petition.html.erb
+++ b/app/views/tools/_petition.html.erb
@@ -40,6 +40,7 @@
         <div class='unsigned'>
           <%= form_for @signature, url: '/tools/petition',
             html: {class: 'petition-tool'} do |f| -%>
+            <%= f.invisible_captcha %>
             <%= f.hidden_field :petition_id -%>
             <input type="hidden" name="action_id" value="<%= @actionPage.id %>" />
 

--- a/app/views/tools/_petition.html.erb
+++ b/app/views/tools/_petition.html.erb
@@ -40,7 +40,7 @@
         <div class='unsigned'>
           <%= form_for @signature, url: '/tools/petition',
             html: {class: 'petition-tool'} do |f| -%>
-            <%= f.invisible_captcha %>
+            <%= invisible_captcha %>
             <%= f.hidden_field :petition_id -%>
             <input type="hidden" name="action_id" value="<%= @actionPage.id %>" />
 

--- a/app/views/tools/_tweet.html.erb
+++ b/app/views/tools/_tweet.html.erb
@@ -78,6 +78,7 @@
   <% unless current_user %>
     <%= form_for :subscription, url: subscriptions_path, remote: true, html: { class: "newsletter-subscription" } do |f| %>
       <hr />
+      <%= f.invisible_captcha %>
       <%= t :sign_up_for_mailings_from %> <b><%= t :organization_abbreviation %></b>?
 
       <fieldset>

--- a/app/views/tools/_tweet.html.erb
+++ b/app/views/tools/_tweet.html.erb
@@ -78,7 +78,7 @@
   <% unless current_user %>
     <%= form_for :subscription, url: subscriptions_path, remote: true, html: { class: "newsletter-subscription" } do |f| %>
       <hr />
-      <%= f.invisible_captcha %>
+      <%= invisible_captcha %>
       <%= t :sign_up_for_mailings_from %> <b><%= t :organization_abbreviation %></b>?
 
       <fieldset>

--- a/config/invisible_captcha.rb
+++ b/config/invisible_captcha.rb
@@ -1,0 +1,4 @@
+InvisibleCaptcha.setup do |config|
+  # Allow cacheing of forms that use invisible captchas.
+  config.timestamp_enabled = false
+end

--- a/lib/civicrm.rb
+++ b/lib/civicrm.rb
@@ -46,12 +46,12 @@ module CiviCRM
   end
 
   def self.subscribe(params)
-    return nil if skip_crm?
+    return {} if skip_crm?
     self.import_contact params.merge(subscribe: true)
   end
 
   def self.import_contact(params)
-    return nil if skip_crm?
+    return {} if skip_crm?
     post base_params.merge(
       method: "import_contact",
       data: {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,6 +103,11 @@ RSpec.configure do |config|
 =end
 end
 
+# Don't prevent form fills by bots during the test run
+InvisibleCaptcha.setup do |config|
+  config.timestamp_enabled = false
+end
+
 # for controller tests
 def login_as_admin
   @request.env["devise.mapping"] = Devise.mappings[:admin]


### PR DESCRIPTION
* Protect mailing list signup endpoints with invisible captcha
* Surface errors from mailing list signup, so we can disable signups if necessary

I didn't put invisible captcha on congress or call actions - I think any bot submissions would have to be tailored to those forms, in which case the invisible captcha wouldn't help.