### PR TITLE
Use fastly-ruby client to issue purge requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,7 @@ supporters_api_key=
 supporters_host=https://actioncenter:somekey@supporters.example.com
 supporters_path=/civicrm/example-action-api
 cors_allowed_domains=https://example.org https://some.example.com
+fastly_api_key=
 
 # Error reporting (not required)
 sentry_dsn=

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ gem "descriptive_statistics"      # Used for calculating percentiles
 gem "devise", "~> 3.5"
 gem "ejs"                         # Embedded javascript
 gem "email_validator"
+gem "fastly"
 gem "friendly_id", "~> 5.0"       # Slugging/permalink plugins for Active Record
 gem "going_postal"                # Zip code validation
 gem "gravatar-ultimate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    fastly (2.2.0)
     ffi (1.9.25)
     fontello_rails_converter (0.4.4)
       activesupport
@@ -507,6 +508,7 @@ DEPENDENCIES
   ejs
   email_validator
   factory_girl_rails
+  fastly
   fontello_rails_converter
   friendly_id (~> 5.0)
   going_postal

--- a/app/controllers/admin/action_pages_controller.rb
+++ b/app/controllers/admin/action_pages_controller.rb
@@ -193,12 +193,10 @@ class Admin::ActionPagesController < Admin::ApplicationController
   end
 
   def purge_cache
-    page = action_page_url(@actionPage)
-    uri = URI.parse("https://api.fastly.com/purge/" + page)
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
-    request = Net::HTTP::Post.new(uri.path, { "Content-Type" => "application/json" })
-    response = http.request(request)
+    if Rails.application.secrets.fastly_api_key.present?
+      fastly = Fastly.new(api_key: Rails.application.secrets.fastly_api_token)
+      fastly.purge action_page_url(@actionPage)
+    end
   end
 
   def cleanup_congress_message_params

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -22,6 +22,7 @@ default: &default
   amazon_region: <%= ENV["amazon_region"] %>
   amazon_bucket: <%= ENV["amazon_bucket"] %>
   amazon_bucket_url: <%= ENV["amazon_bucket_url"] %>
+  fastly_api_key: <%= ENV["fastly_api_key"] %>
   smarty_streets_id: <%= ENV["smarty_streets_id"] %>
   smarty_streets_token: <%= ENV["smarty_streets_token"] %>
   congress_forms_debug_key: <%= ENV["congress_forms_debug_key"] %>


### PR DESCRIPTION
POSTing to /purge is no longer the preferred way to issue purge requests, according to the Fastly gem:

> Previously purging made an POST call to the /purge endpoint of the Fastly API.
>
> The new method of purging is done by making an HTTP request against the URL using the PURGE HTTP method.

https://github.com/fastly/fastly-ruby

The only appearance of /purge in their docs[1] suggests that it requires an API key. Issuing an HTTP PURGE directly to the URL doesn't, but there's not a clean way to do that with net/http or the rest-client gems -- so instead I'm bundling the fastly-ruby gem, and will add an API token to our production environment.

[1] https://docs.fastly.com/guides/purging/authenticating-api-purge-requests#purging-urls-with-an-api-token