### PR TITLE
Correctly read DNT param for email actions

### DIFF
--- a/app/assets/javascripts/application/tools/email.js.erb
+++ b/app/assets/javascripts/application/tools/email.js.erb
@@ -1,7 +1,8 @@
 $(document).on('ready', function() {
   var dnt = false;
   $('#target-email .email-action').click(function(){
-    // we need this timeout so the value isn't changed before submission
+    // Set DNT to true after submission so we don't track subsequent submits.
+    // We need this timeout so the value isn't changed before submission.
     setTimeout(function() {
       if (!dnt) { $('input[name="dnt"]').val('true'); }
       dnt = true;

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -133,7 +133,7 @@ class ToolsController < ApplicationController
   end
 
   def email
-    unless (@user and @user.events.emails.find_by_action_page_id(params[:action_id])) or params.include? :dnt
+    unless (@user and @user.events.emails.find_by_action_page_id(params[:action_id])) or params[:dnt] == "true"
       ahoy.track "Action",
         { type: "action", actionType: "email", actionPageId: params[:action_id] },
         action_page: @action_page


### PR DESCRIPTION
For Redmine #20006 - the param comes in as "false" rather than being empty.