### PR TITLE
Revert "Log outgoing mail in prod"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,7 +17,6 @@ Actioncenter::Application.configure do
 
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.logger = Logger.new STDOUT
 
 
   config.action_mailer.default_url_options = { :host => Rails.application.secrets.smtp_domain, :protocol => 'https' }


### PR DESCRIPTION
This reverts commit d88d37ec9450fc7f78f070523af7ec8af228bce5.

We used this to debug a production-only email problem, it's no longer needed.