### PR TITLE
Removal of Google Plus references/share option.

### DIFF
--- a/app/assets/javascripts/application/social-buttons.js
+++ b/app/assets/javascripts/application/social-buttons.js
@@ -16,11 +16,6 @@ $(document).on('ready', function() {
       window.open(url, "Twitter", "width=550,height=420");
       return false;
     })
-    $(".google-button").click(function() {
-      var url = $(this).attr("href");
-      window.open(url, "Share on Google Plus", "width=500,height=436");
-      return false;
-    })
   }
 
 });

--- a/app/helpers/action_page_helper.rb
+++ b/app/helpers/action_page_helper.rb
@@ -14,10 +14,6 @@ module ActionPageHelper
     "https://twitter.com/intent/tweet?status=#{u message}&related=#{related}"
   end
 
-  def google_share_url(action_page)
-    "https://plus.google.com/share?url=#{action_page_url(action_page)}"
-  end
-
   def tweet_url(target, message)
     target = "@#{target}" unless target.starts_with? "@"
     message = [target, message].compact.join(" ")

--- a/app/views/admin/action_pages/_panel_email.html.erb
+++ b/app/views/admin/action_pages/_panel_email.html.erb
@@ -13,7 +13,7 @@
     <p>Special strings shown below are automatically replaced with generated content.</p>
     <br>
     <h3>Auto-inserted text</h3>
-    <p><strong>$SHAREBUTTONS</strong> is replaced with Facebook/Twitter/Google Plus/Email share buttons</p>
+    <p><strong>$SHAREBUTTONS</strong> is replaced with Facebook/Twitter/Email share buttons</p>
     <p><strong>$TITLE</strong> is replaced with title of the action.</p>
     <p><strong>$URL</strong> is replaced with the URL of the page they took action on.</p>
     <p><strong>$NAME</strong> is resplaced the user's first name if available, or "Friend of Digital Freedom".</p>

--- a/app/views/tools/_container.html.erb
+++ b/app/views/tools/_container.html.erb
@@ -20,9 +20,6 @@
         <a href="<%= facebook_share_url(@actionPage) -%>" data-network="facebook" count="0" target="_blank" class="facebook-button">
             <div class="sicon" id="sfb"></div>
         </a>
-        <a count="0" href="<%= google_share_url(@actionPage) -%>" data-network="googleplus" target="_blank" class="google-button">
-          <div class="sicon" id="sgplus"></div>
-        </a>
       </div>
     </div>
   </div>

--- a/app/views/tools/_share.html.erb
+++ b/app/views/tools/_share.html.erb
@@ -8,11 +8,6 @@
     <div class="sicon" id="sfb"></div>
     <div class="share-label">Share on Facebook</div>
   </a>
-  <a href="<%= google_share_url(@actionPage) -%>" class="google google-button">
-    <div class="sicon" id="sgplus"></div>
-    <div class="share-label">Share on Google+</div>
-  </a>
-
 </div>
 <p class="small donate">
   Have you <a href="https://supporters.eff.org/donate" target="blank">donated to EFF</a> lately?

--- a/app/views/user_mailer/_sharing.html.erb
+++ b/app/views/user_mailer/_sharing.html.erb
@@ -5,9 +5,6 @@
   <a href='<%= twitter_share_url(@actionPage) -%>'>
     <%= image_tag 'share-on-tw-thin.png', alt: 'Share on Twitter' -%>
   </a>
-  <a href='<%= google_share_url(@actionPage) -%>'>
-    <%= image_tag 'share-on-g-thin.png', alt: 'Share on Google Plus' -%>
-  </a>
   <a href='<%= email_friends_url(@actionPage) -%>'>
     <%= image_tag 'share-on-email-thin.png', alt: 'Send an email' -%>
   </a>

--- a/app/views/user_mailer/_sharing.text.erb
+++ b/app/views/user_mailer/_sharing.text.erb
@@ -4,8 +4,5 @@ Share on Facebook:
 Share on Twitter:
 <%= twitter_share_url(@actionPage) %>
 
-Share on Google Plus:
-<%= google_share_url(@actionPage) %>
-
 Send an Email:
 <%= email_friends_url(@actionPage) %>


### PR DESCRIPTION
Pertains to https://github.com/EFForg/action-center-platform/issues/484.

Google Plus now no longer existing means there's no point having Google+ share buttons, so they have been removed and associated references too.