### PR TITLE
Reset password for unconfirmed users

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -24,7 +24,13 @@ class RegistrationsController < Devise::RegistrationsController
     resource.errors.delete(:email)
 
     if resource.errors.empty?
-      User.find_by_email(resource.email).send_email_taken_notice
+      existing = User.find_by_email(resource.email)
+      existing.send_email_taken_notice
+
+      # Allow unconfirmed users to set a new password by re-registering.
+      if !existing.confirmed?
+        existing.update_attributes(sign_up_params)
+      end
 
       if resource.persisted?
         resource.update_attribute(:unconfirmed_email, account_update_params[:email])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,6 +125,13 @@ class User < ActiveRecord::Base
     self.last.nil? ? 1 : self.last.id + 1
   end
 
+  # We're allowing unconfirmed users to reset their passwords by
+  # re-registering. In that case, they shouldn't get a password reset
+  # notification.
+  def send_password_change_notification?
+    self.confirmed? && super
+  end
+
   protected
 
   def after_confirmation

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "Registrations", type: :request do
+  before do
+    stub_civicrm
+  end
+
+  describe "creates users" do
+    let(:valid_attributes) do
+      {
+        user: {
+          email: "buffy@sunnydale.edu",
+          password: "mrpointy",
+          password_confirmation: "mrpointy"
+        }
+      }
+    end
+    subject { post "/", params: valid_attributes }
+
+    it "creates users" do
+      subject
+      expect(response.code).to eq "302"
+      expect(User.count).to eq 1
+      # Expect an email confirmation message.
+      expect(ActionMailer::Base.deliveries.count).to eq 1
+    end
+
+    it "lets unconfirmed users register a new password" do
+      subject
+      # Attempt to re-register+confirm with a new password,
+      post "/", params: {
+        user: {
+          email: "buffy@sunnydale.edu",
+          password: "hellmouth",
+          password_confirmation: "hellmouth"
+        }
+      }
+      expect(response.code).to eq "302"
+      user = User.first
+      user.confirm
+
+      # User should now be able to log in with the new password.
+      expect(user.valid_password?("hellmouth")).to be true
+      # Expect two email confirmations, no password reset notice.
+      expect(ActionMailer::Base.deliveries.count).to eq 2
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "Tests about users", type: :request do
   before(:each) do
     stub_civicrm
-    @action_page = FactoryGirl.create(:petition_with_99_signatures_needing_1_more).action_page
     @user = FactoryGirl.create(:user)
   end
 


### PR DESCRIPTION
When a user has an unconfirmed account and they try to register again with the same e-mail, update the password associated with the confirmed account.

Closes #471 