### PR TITLE
Fix password reset link

### DIFF
--- a/app/views/user_mailer/signup_attempt_with_existing_email.html.erb
+++ b/app/views/user_mailer/signup_attempt_with_existing_email.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone tried to create Action Center account with this e-mail address, but an account already exists. If you forgot your password, you can change it with the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@user, :reset_password_token => @token) %></p>
+<p><%= link_to 'Change my password', new_password_url(@user, :reset_password_token => @token) %></p>
 
 <p>Your password won't change until you access the link above and create a new one.</p>
 <p>This link will expire in 6 hours.</p>

--- a/app/views/user_mailer/signup_attempt_with_existing_email.text.erb
+++ b/app/views/user_mailer/signup_attempt_with_existing_email.text.erb
@@ -2,7 +2,7 @@ Hello <%= @user.email %>!
 
 Someone tried to sign up for a new Action Center account with this e-mail address, but an account already exists. If you forgot your password, you can change it with the link below.
 
-<%= edit_password_url(@user, :reset_password_token => @token) %>
+<%= new_password_url(@user, :reset_password_token => @token) %>
 
 Your password won't change until you access the link above and create a new one.
 This link will expire in 6 hours.


### PR DESCRIPTION
`edit_password_url` goes to the page users should reach *after* following a confirmation link.