### PR TITLE
Allow sweetalert cookie

### DIFF
--- a/varnish.vcl
+++ b/varnish.vcl
@@ -12,6 +12,10 @@ sub vcl_recv {
       return(pass);
   }
 
+  if (req.http.cookie ~ "^sweetAlert") {
+      return(pass);
+  }
+
   if (req.url !~ "^/(ahoy)/") {
       unset req.http.Cookie;
   }
@@ -20,7 +24,7 @@ sub vcl_recv {
 }
 
 sub vcl_fetch {
-  if (req.http.cookie !~ "logged_in" && req.url !~ "^/(login)|(register)|(confirmation/new)|(unlock/new)|(password/new)|(password/edit)|(ahoy/)") {
+  if (req.http.cookie !~ "logged_in" && beresp.http.Set-Cookie !~ "^sweetAlert" && req.url !~ "^/(login)|(register)|(confirmation/new)|(unlock/new)|(password/new)|(password/edit)|(ahoy/)") {
       unset beresp.http.Set-Cookie;
   }
 


### PR DESCRIPTION
Fixes #470 

Sweetalert shows an alert on redirect by putting it in a cookie on the 302 response. We need to retain the Set-Cookie header on 302 response (line 27) and retain the cookie itself on the redirected request to `/` (line 15).

This is deployed to our staging Fastly config.