### PR TITLE
Invisible Captcha logging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include ApplicationHelper
   include RequestOriginValidation
+  include LoggedInvisibleCaptcha
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/concerns/logged_invisible_captcha.rb
+++ b/app/controllers/concerns/logged_invisible_captcha.rb
@@ -1,22 +1,14 @@
 module LoggedInvisibleCaptcha
   extend ActiveSupport::Concern
 
-  module ClassMethods
-    def logged_invisible_captcha(options = {})
-      options[:on_spam] = :logged_on_spam
-      options[:on_timestamp_spam] = :logged_on_timestamp_spam
-      invisible_captcha options
-    end
+  def on_spam(options = {})
+    log_failure
+    super options
   end
 
-  def logged_on_spam
+  def on_timestamp_spam(options = {})
     log_failure
-    on_spam
-  end
-
-  def logged_on_timestamp_spam
-    log_failure
-    on_timestamp_spam
+    super options
   end
 
   def log_failure

--- a/app/controllers/concerns/logged_invisible_captcha.rb
+++ b/app/controllers/concerns/logged_invisible_captcha.rb
@@ -1,0 +1,26 @@
+module LoggedInvisibleCaptcha
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def logged_invisible_captcha(options = {})
+      options[:on_spam] = :logged_on_spam
+      options[:on_timestamp_spam] = :logged_on_timestamp_spam
+      invisible_captcha options
+    end
+  end
+
+  def logged_on_spam
+    log_failure
+    on_spam
+  end
+
+  def logged_on_timestamp_spam
+    log_failure
+    on_timestamp_spam
+  end
+
+  def log_failure
+    Raven.capture_message("A suspected automated form fill was rejected",
+                          level: :info)
+  end
+end

--- a/spec/controllers/concerns/logged_invisible_captcha_spec.rb
+++ b/spec/controllers/concerns/logged_invisible_captcha_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe LoggedInvisibleCaptcha, type: :controller do
+  controller(ApplicationController) do
+    # include LoggedInvisibleCaptcha
+    invisible_captcha honeypot: :foo, only: :create
+
+    def create
+      byebug
+    end
+  end
+
+  it "blocks requests with a timestamp" do
+    expect(controller).not_to receive(:create)
+    post :create, foo: "bar"
+  end
+end

--- a/spec/controllers/concerns/logged_invisible_captcha_spec.rb
+++ b/spec/controllers/concerns/logged_invisible_captcha_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe LoggedInvisibleCaptcha, type: :controller do
   controller(ApplicationController) do
-    include LoggedInvisibleCaptcha
     invisible_captcha honeypot: :foo, only: :create
 
     def create; end

--- a/spec/controllers/concerns/logged_invisible_captcha_spec.rb
+++ b/spec/controllers/concerns/logged_invisible_captcha_spec.rb
@@ -2,16 +2,19 @@ require "rails_helper"
 
 RSpec.describe LoggedInvisibleCaptcha, type: :controller do
   controller(ApplicationController) do
-    # include LoggedInvisibleCaptcha
-    invisible_captcha honeypot: :foo, only: :create
+    include LoggedInvisibleCaptcha
+    logged_invisible_captcha honeypot: :foo, only: :create
 
-    def create
-      byebug
-    end
+    def create; end
   end
 
-  it "blocks requests with a timestamp" do
+  it "blocks requests that fill the honeypot" do
     expect(controller).not_to receive(:create)
+    post :create, foo: "bar"
+  end
+
+  it "logs spammy requests to Sentry" do
+    expect(Raven).to receive(:capture_message)
     post :create, foo: "bar"
   end
 end

--- a/spec/controllers/concerns/logged_invisible_captcha_spec.rb
+++ b/spec/controllers/concerns/logged_invisible_captcha_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe LoggedInvisibleCaptcha, type: :controller do
   controller(ApplicationController) do
     include LoggedInvisibleCaptcha
-    logged_invisible_captcha honeypot: :foo, only: :create
+    invisible_captcha honeypot: :foo, only: :create
 
     def create; end
   end


### PR DESCRIPTION
Log to Sentry when `invisible_captcha` rejects a form fill. Request url and ip are automatically collected by Raven.

Closes #457 