### PR TITLE
Send RestClient errors to Sentry

### DIFF
--- a/lib/civicrm.rb
+++ b/lib/civicrm.rb
@@ -90,6 +90,7 @@ module CiviCRM
       raise res["error_message"] if res["error"]
       return res
     rescue => e
+      Raven.capture_exception(e)
       Rails.logger.error "#{ e } (#{ e.class })!"
       return false
     end

--- a/lib/congress_forms.rb
+++ b/lib/congress_forms.rb
@@ -13,6 +13,7 @@ module CongressForms
     begin
       JSON.parse RestClient.get(url(path, params, bioguide_id))
     rescue RestClient::ExceptionWithResponse => e
+      Raven.capture_exception(e)
       Rails.logger.error e
       return {}
     end

--- a/lib/smarty_streets.rb
+++ b/lib/smarty_streets.rb
@@ -25,6 +25,7 @@ module SmartyStreets
       res = JSON.parse RestClient.get("#{url}?#{params.to_query}")
       return res
     rescue => e
+      Raven.capture_exception(e)
       Rails.logger.error "#{ e } (#{ e.class })!"
       return false
     end


### PR DESCRIPTION
Based on https://github.com/getsentry/raven-ruby/issues/186#issuecomment-46745481 I think it's better if we just log to Sentry as needed. Doing that here for our failing RestClient calls so we can better track integration issues.

Closes #335 