### PR TITLE
Remove bootstrap from sticky_tools js

### DIFF
--- a/app/assets/javascripts/application/sticky_tools.js
+++ b/app/assets/javascripts/application/sticky_tools.js
@@ -1,5 +1,3 @@
-//= require bootstrap/affix
-
 $(function() {
   var s = $('#tools');
   var t = $('.redtop .row');


### PR DESCRIPTION
Closes #513 

turns out we weren't using bootstrap functions for this functionality! This removes the unnecessary require.