### PR TITLE
Add comment to clarify logged_in cookie

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,6 +5,7 @@ class SessionsController < Devise::SessionsController
   def set_logged_in
     if (user_signed_in?)
       # Sets a "permanent" cookie (which expires in 20 years from now).
+      # This is exclusively used to never cache content for logged in users
       cookies.permanent[:logged_in] = "I <3 EFF"
     end
   end


### PR DESCRIPTION
This cookie's name sort of implies that it has to do with session management, and if it did, it'd probably be a security issue. This PR adds a comment explaining what it's used for in order to prevent future worrying & digging into the codebase.