### PR TITLE
Update redesign branch for backend congress forms

### DIFF
--- a/app/views/tools/_congress_message.html.erb
+++ b/app/views/tools/_congress_message.html.erb
@@ -3,7 +3,7 @@
     <div class="tool-heading">
       <h2 class="tool-title"><%= @congress_message_campaign.email_your_rep_text "Take Action" %></h2>
       <% if params.include?("non_us_option") and params["non_us_option"] == "petition" %>
-      <h3 id="non-us-option">Not in the U.S.?</h3>
+        <h3 id="non-us-option">Not in the U.S.?</h3>
       <% end %>
     </div>
 
@@ -11,81 +11,68 @@
       <%= form_tag(new_congress_message_campaign_congress_message_path(@congress_message_campaign),
                    method: :get, remote: true,
                    class: "form congress-message-rep-lookup") do %>
-          <% unless @congress_message_campaign.target_bioguide_ids.present? %>
-            <fieldset id="lookup-address">
-              <h3>
-                <span class="customize-message-popover" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="auto bottom" data-content="<%= @congress_message_campaign.look_up_helper_text "We'll use your address to look up your congressional district and find your representatives." %>">?</span>
-                <em><%= @congress_message_campaign.look_up_your_rep_text "Look up your representatives" %></em>
-              </h3>
-              <div id="errors"></div>
-
-              <div class="form-group">
-                <%= text_field_tag :street_address,
-                                   (current_user && current_user.street_address),
-                                   placeholder: "Street Address",
-                                   "aria-label": "Street Address",
-                                   required: true,
-                                   class: "form-control" %>
-              </div>
-
-              <div class="form-group">
-                <%= text_field_tag :zipcode,
-                                   (current_user && current_user.zipcode),
-                                   placeholder: "Zip Code",
-                                   "aria-label": "Zip Code",
-                                   required: true,
-                                   class: "form-control",
-                                   title: "Must be 5 numeric numbers",
-                                   pattern: "\\d{5}",
-                                   maxlength: 5 %>
-              </div>
-              <p class="privacy-notice">This tool uses the <a href="http://smartystreets.com/legal/privacy-policy" target="_blank">Smarty Streets</a> API (<a class="privacy-notice-popover" href="#" data-container="body" data-toggle="popover" data-title="Email Tool APIs" data-html="true" data-trigger="hover" data-placement="auto" data-content="<p>We need your full address to locate your exact congressional district, but this information isn't stored unless you're logged in.</p><p>We also use the Smarty Streets' API to look up your full 9 digit zip code (Zip+4), since some Congressmember's forms require it.</p>">why?</a>).<br>
-              If you prefer not to use our email tool, <a href="https://www.eff.org/congress"  target="_blank">click here</a>.</p>
-            </fieldset>
-          <% end %>
-          <fieldset id="customize-message">
+        <% unless @congress_message_campaign.target_bioguide_ids.present? %>
+          <fieldset id="lookup-address">
             <h3>
-              <span class="customize-message-popover" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="auto bottom" data-content="<%= @congress_message_campaign.customize_message_helper_text "Add a personal note about why this matters to you. Members of Congress value a customized message much higher than a form letter." %>">?</span>
-              <em>Customize your message</em>
+              <span class="customize-message-popover" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="auto bottom" data-content="<%= @congress_message_campaign.look_up_helper_text "We'll use your address to look up your congressional district and find your representatives." %>">?</span>
+              <em><%= @congress_message_campaign.look_up_your_rep_text "Look up your representatives" %></em>
             </h3>
-            <div class="form-group">
-              <%= text_area_tag :message, @congress_message_campaign.message,
-                                class: "campaign-message form-control",
-                                rows: 11 %>
-            </div>
-          </fieldset>
-          <%= render "tools/privacy_notice" %>
+            <div id="errors"></div>
 
-          <input type="submit" class="btn btn-default action" value="Submit your message">
-          <%= render "tools/loading" -%>
+            <div class="form-group">
+              <%= text_field_tag :street_address,
+                                 (current_user && current_user.street_address),
+                                 placeholder: "Street Address",
+                                 "aria-label": "Street Address",
+                                 required: true,
+                                 class: "form-control" %>
+            </div>
+
+            <div class="form-group">
+              <%= text_field_tag :zipcode,
+                                 (current_user && current_user.zipcode),
+                                 placeholder: "Zip Code",
+                                 "aria-label": "Zip Code",
+                                 required: true,
+                                 class: "form-control",
+                                 title: "Must be 5 numeric numbers",
+                                 pattern: "\\d{5}",
+                                 maxlength: 5 %>
+            </div>
+            <p class="privacy-notice">This tool uses the <a href="http://smartystreets.com/legal/privacy-policy" target="_blank">Smarty Streets</a> API (<a class="privacy-notice-popover" href="#" data-container="body" data-toggle="popover" data-title="Email Tool APIs" data-html="true" data-trigger="hover" data-placement="auto" data-content="<p>We need your full address to locate your exact congressional district, but this information isn't stored unless you're logged in.</p><p>We also use the Smarty Streets' API to look up your full 9 digit zip code (Zip+4), since some Congressmember's forms require it.</p>">why?</a>).<br>
+            If you prefer not to use our email tool, <a href="https://www.eff.org/congress"  target="_blank">click here</a>.</p>
+          </fieldset>
         <% end %>
 
-        <div id="email-signup-container" style="display:none;">
-          <%= render "tools/newsletter_signup", email: false, location: false, privacy_notice: false %>
-        </div>
+        <fieldset id="customize-message">
+          <h3>
+            <span class="customize-message-popover" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="auto bottom" data-content="<%= @congress_message_campaign.customize_message_helper_text "Add a personal note about why this matters to you. Members of Congress value a customized message much higher than a form letter." %>">?</span>
+            <em>Customize your message</em>
+          </h3>
+          <div class="form-group">
+            <%= text_area_tag :message, @congress_message_campaign.message,
+                              class: "campaign-message form-control",
+                              rows: 11 %>
+          </div>
+        </fieldset>
+        <%= render "tools/privacy_notice" %>
 
-        <div class="congress-message-tool-container"></div>
-
-      <div class="thank-you" style="display: none;">
-        <div class="alert alert-success">Thank you for the email</div>
-      </div>
+        <input type="submit" class="btn btn-default action" value="Submit your message">
+        <%= render "tools/loading" -%>
+      <% end %>
 
       <div id="email-signup-container" style="display:none;">
         <%= render "tools/newsletter_signup", email: false, location: false, privacy_notice: false %>
       </div>
 
-      <%= content_tag(:div, nil, :class => "congress-message-tool-container",
-      :data => {
-        "congress-forms-url": Rails.application.config.congress_forms_url,
-        "campaign-tag": @congress_message_campaign.campaign_tag,
-        "email-values": congress_forms_email_values(@congress_message_campaign, @location).to_json,
-        "target-house": @congress_message_campaign.target_house,
-        "target-senate": @congress_message_campaign.target_senate,
-        "extra-fields-explain": @congress_message_campaign.extra_fields_explain_text("We send your comments to your representatives by automatically filling out their online contact forms. Because each representative's form is a little different, we need your help filling out a few extra fields before we can send your message:"),
-        "bioguide-ids": bioguide_ids(@congress_message_campaign, @target_bioguide_ids),
-        "topic-category": @topic_category.to_json
-      }) %>
+      <div class="congress-message-tool-container"></div>
+
+      <div class="email-tool-success-share" style="display: none;">
+        <%= render "tools/share" -%>
+      </div>
+
     </div>
+
     <div class="tool-body without-js">
       <h4><strong>Our email tool requires javascript.</strong></h4>
       <p>If your browser doesn't support javascript or you prefer not to enable javascript on this site, you can find your legislator's contact forms via the <a target="_blank" href="http://www.house.gov/representatives/find/">House</a> and <a target="_blank" href="https://www.senate.gov/general/contact_information/senators_cfm.cfm">Senate</a> websites.</p>
@@ -95,14 +82,4 @@
       </form>
     </div>
   </div>
-</div>
-
-<div class="update-user-data-container" style="display: none;">
-  <% if current_user %>
-  <div class="checkbox small">
-    <label for="update_user_data">
-      <input checked="checked" id="update_user_data" name="update_user_data" type="checkbox" value="yes">    Save my name and address for next time.
-    </label>
-  </div>
-  <% end %>
 </div>


### PR DESCRIPTION
Update the redesign branch to work with backend congress forms. This really just involved removing the old div that held all the data required to generate the forms on the frontend.

The markup for actual reps' forms (previously generated in js) can now be found in `/app/views/congress_messages/_form.html.erb`. It might need some updates to work well with the new styles. 