### PR TITLE
Check if an image is present more safely

### DIFF
--- a/app/views/action_page/_meta_tags.html.erb
+++ b/app/views/action_page/_meta_tags.html.erb
@@ -1,6 +1,6 @@
 <% summary = strip_tags stripdown(@actionPage.summary) -%>
 <%
-    image_url = if @actionPage.image.exists?
+    image_url = if @actionPage.image.try(:exists?)
                   image_url(@actionPage.image.to_s)
                 else
                   image_url("og-image-default.png")


### PR DESCRIPTION
Allows actions without images to be viewed -- if there's no image object right now, `#exists?` throws an error.