### PR TITLE
Fix previews

### DIFF
--- a/app/controllers/admin/action_pages_controller.rb
+++ b/app/controllers/admin/action_pages_controller.rb
@@ -114,6 +114,8 @@ class Admin::ActionPagesController < Admin::ApplicationController
                               zipcode: current_zipcode,
                               country_code: current_country_code,
                               email: current_email }
+    @related_content = RelatedContent.new(@actionPage.related_content_url)
+    @related_content.load
 
     render "action_page/show", layout: "application"
   end


### PR DESCRIPTION
sorta for #693 -- previews were broken after adding related content. This doesn't fix previews for new actions (the functionality was originally written only for editing actions, and we're leaving that as-is for now)