### PR TITLE
Fix #746 "Save removes paragraphs"

### DIFF
--- a/app/assets/javascripts/admin/editor.js.erb
+++ b/app/assets/javascripts/admin/editor.js.erb
@@ -27,5 +27,6 @@ function reflowEpicEditor() {
       initEpicEditor(this);
 
     $(this).data('editor').reflow();
+    $(this).data('editor')._canSave = true;
   });
 }

--- a/app/assets/javascripts/admin/tabs.js
+++ b/app/assets/javascripts/admin/tabs.js
@@ -2,6 +2,13 @@
   var goto = function(id) {
     if (!id) return;
 
+    // Don't allow hidden epiceditors to save -- when the element
+    // is hidden, whitespace formatting doesn't export correctly.
+    $('#content form .page:visible .epiceditor').each(function() {
+      if ($(this).data('editor'))
+        $(this).data('editor')._canSave = false;
+    });
+
     $('#content form .page:visible').fadeOut(100, function() {
       $('#nav .active').removeClass('active');
       $('#nav a[href=' + id +']').addClass('active');


### PR DESCRIPTION
Epiceditor doesn't correctly export line breaks into the textarea when the iframe element is invisible. The textarea is automatically updated [every 100ms](https://github.com/OscarGodson/EpicEditor/blob/15802f057222d12ce4a0185594092b932a7127b2/src/editor.js#L1158-L1163) (even when autoSave is set to false `:\`), so this means as the user moves through tabs while editing an action page, content in the editors they're navigating away from gets overwritten with an incorrect value.

This branch provides a quick fix for the issue by linking the editor's `_canSave` attribute (which is internal state?) to it's visibility.