### PR TITLE
adding code to check #action-content so .offset() doesn't error (embeds)

### DIFF
--- a/app/assets/javascripts/application/tools/congress_message.js
+++ b/app/assets/javascripts/application/tools/congress_message.js
@@ -18,7 +18,9 @@ $(document).on("ready", function() {
   $(".congress-message-rep-lookup").on("ajax:complete", function(xhr, data, status) {
     var $form = $(this);
     if (status == "success") {
-      $(window).scrollTop( $("#action-content").offset().top ); // go to top of page
+      if ($("#action-content").length) {
+        $(window).scrollTop( $("#action-content").offset().top ); // go to top of page if on action center site
+      }
       update_tabs(1, 2);
       $(".progress-striped").hide();
       $form.remove();
@@ -37,7 +39,9 @@ $(document).on("ready", function() {
   $("#congress-message-tool").on("click", "#to-page-3", function(){
     $(".rep-info").hide();
     $("#customize-message").show();
-    $(window).scrollTop( $("#action-content").offset().top ); // go to top of page
+    if ($("#action-content").length) {
+      $(window).scrollTop( $("#action-content").offset().top ); // go to top of page if on action center site
+    }
     update_tabs(2, 3);
   });
 
@@ -59,7 +63,9 @@ $(document).on("ready", function() {
         $("#congress-message-create").hide();
         $("#congress-message-tool").hide();
         $('.thank-you').show();
-        $(window).scrollTop( $("#action-content").offset().top ); // go to top of page
+        if ($("#action-content").length) {
+          $(window).scrollTop( $("#action-content").offset().top ); // go to top of page if on action center site
+        }
         update_tabs(3, 4);
       },
       error: function(data) {


### PR DESCRIPTION
On embedded actions, jquery .offset() is throwing an error b/c #action-content doesn't exist. It only exists on the action center site. Adding code to check it exists before using .offset().