### PR TITLE
Avoid class variables in analytics calculations

### DIFF
--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -78,9 +78,7 @@ module Ahoy
     end
 
     def self.summary
-      @view_count ||= views.count
-      @action_count ||= actions.count
-      { view: @view_count, action: @action_count }
+      { view: views.count, action: actions.count }
     end
 
     def user_opt_out


### PR DESCRIPTION
The instance variables set in the `.summary` method belong to the whole `Ahoy::Event` class, not a particular query or action page. I believe this is causing the issue where all pages in production show the same summarized analytics numbers. It may not have been an issue in development due to `Ahoy::Event` getting reloaded between requests.