### PR TITLE
Make header text on act.eff.org clickable

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -48,9 +48,8 @@
           <% end %>
           <div class="more-actions-text">
 
-            <h3><%= actionPage.title -%>
             <%= link_to action_page_path(actionPage) do%>
-            </h3>
+            <h3><%= actionPage.title -%></h3>
             <p> <%= markdown actionPage.summary -%></p>
             <% end %>
           </div>


### PR DESCRIPTION
Fixes Issue #812

It looks like this may have been intentional. This is the breaking
commit:
https://github.com/EFForg/action-center-platform/commit/e56580df103043c9b0d8a20de4ad4105a698fc03#diff-274d864769a5a983294b02ecded7e61dL51


Feel free to ignore my PRs - I won't be sad 😁 