### PR TITLE
Appease rubocop

### DIFF
--- a/app/controllers/concerns/date_range.rb
+++ b/app/controllers/concerns/date_range.rb
@@ -20,7 +20,7 @@ module DateRange
 
   # Convert Last X (days|weeks|months) to a time
   def parse_time_ago(string)
-    _, count, unit = string.split(' ')
+    _, count, unit = string.split(" ")
     return Time.zone.now - 1.month unless %w(days weeks months years).include? unit
     Time.zone.now - count.to_i.send(unit)
   end

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -2,7 +2,7 @@ class ExceptionsController < ActionController::Base
   layout "application"
 
   def show
-   @exception       = request.env["action_dispatch.exception"]
+    @exception       = request.env["action_dispatch.exception"]
     @status_code     = ActionDispatch::ExceptionWrapper.new(request.env, @exception).status_code
     @rescue_response = ActionDispatch::ExceptionWrapper.rescue_responses[@exception.class.name]
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -109,7 +109,7 @@ module ApplicationHelper
   end
 
   def percentage(x, y, precision: 0)
-    return '-' unless y > 0
+    return "-" unless y > 0
     number_to_percentage((x / y.to_f) * 100, precision: precision)
   end
 

--- a/app/models/action_institution.rb
+++ b/app/models/action_institution.rb
@@ -21,7 +21,7 @@ class ActionInstitution < ActiveRecord::Base
         check_for_existing: true,
         unique: true
       },
-      variable_column: 'institution_id',
+      variable_column: "institution_id",
       values: institution_ids
     }
     FastInserter::Base.new(insert_params).fast_insert

--- a/spec/features/action_pages/congress_action_spec.rb
+++ b/spec/features/action_pages/congress_action_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Congress actions", type: :feature, js: true do
     fill_in "Your last name", with: "Dax"
     select "Dr.", from: "Your prefix"
     topic_fields = find_all("select[aria-label='Choose a topic']")
-    topic_fields.each { |f| f.find_all('option').last.select_option }
+    topic_fields.each { |f| f.find_all("option").last.select_option }
     click_on "Next >"
 
     # Page 3: send message

--- a/spec/features/admin/action_creation_spec.rb
+++ b/spec/features/admin/action_creation_spec.rb
@@ -134,6 +134,6 @@ RSpec.describe "Admin action page creation", type: :feature, js: true do
   end
 
   def select_action_type(type)
-    find("#action_type_#{type}").ancestor('label').click
+    find("#action_type_#{type}").ancestor("label").click
   end
 end

--- a/spec/models/ahoy/event_spec.rb
+++ b/spec/models/ahoy/event_spec.rb
@@ -8,9 +8,9 @@ describe Ahoy::Event do
     end
   end
 
-  describe 'calculations' do
+  describe "calculations" do
     let!(:now) { Time.zone.parse("12-11-2019 11:00 AM") }
-    let!(:page) do 
+    let!(:page) do
       FactoryGirl.create(:action_page_with_petition,
                          created_at: now - 1.week, updated_at: now)
     end
@@ -24,7 +24,7 @@ describe Ahoy::Event do
       page.reload
     end
 
-    describe '.counts_by_date' do
+    describe ".counts_by_date" do
       it "returns a hash with :counts of views and actions by date" do
         result = page.events.table_data
         target_date = now.strftime("%b %-e %Y")
@@ -32,7 +32,7 @@ describe Ahoy::Event do
       end
     end
 
-    describe '.summary' do
+    describe ".summary" do
       it "returns a hash with :summary of total views and actions" do
         result = page.events.summary
         expect(result).to eq({ view: 5, action: 2 })

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -19,7 +19,7 @@ module FeatureHelpers
   end
 
   def fill_in_select2(locator, with:)
-    find(locator).sibling('.select2-container').click
+    find(locator).sibling(".select2-container").click
     find('li.select2-results__option[role="treeitem"]', text: with).click
   end
 end


### PR DESCRIPTION
Fix the problems that upset rubocop. In this case, they were mostly
double/single quotes e.g.:

```
spec/support/feature_helpers.rb:22:27: C: [Corrected]
Style/StringLiterals: Prefer double-quoted strings unless you need
single quotes to avoid extra backslashes for escaping.
    find(locator).sibling('.select2-container').click
```

Also there was a misalignment in the ExceptionsController