### PR TITLE
Don't prompt for redirect URL when archiving action

### DIFF
--- a/app/assets/javascripts/admin/action_pages.js
+++ b/app/assets/javascripts/admin/action_pages.js
@@ -51,12 +51,6 @@ $('.action_page_setup').on('click', '#nav a[href=#save]', function(e) {
   $('form', '#content').first().submit();
 });
 
-$('.action_pages-status').on('change', 'input[type="radio"]', function() {
-  var archive_selected = $(this).val() == "archived";
-  $('#archive-redirect').toggle(archive_selected);
-  $('#archive-redirect input[type="hidden"]').val(archive_selected);
-});
-
 $('.action_page_setup').on('change', '#action_page_petition_attributes_enable_affiliations', function() {
   $('#affiliations-enabled').toggle($(this).prop('checked'));
 });

--- a/app/views/admin/action_pages/status.html.erb
+++ b/app/views/admin/action_pages/status.html.erb
@@ -34,11 +34,6 @@
     </div>
   </fieldset>
 
-  <div id="archive-redirect" class="<%= 'hidden' unless @actionPage.archived? %>">
-    <%= f.hidden_field :enable_redirect %>
-    <%= render "redirect_fields", f: f %>
-  </div>
-
   <div class="form-actions">
     <%= f.submit "Update", class: "btn btn-primary" %>
   </div>


### PR DESCRIPTION
Archived pages are considered unpublished and so aren't working as redirects at the moment. Elliot suggested we just remove the redirect_url input for archived pages -- they'll be kept live and made a redirect via the action settings instead.