### PR TITLE
Add notice about message customization to congress actions

### DIFF
--- a/app/assets/javascripts/application/tools/congress_message.js
+++ b/app/assets/javascripts/application/tools/congress_message.js
@@ -53,6 +53,19 @@ $(document).on("ready", function() {
   $(".congress-message-tool-container").on("click", "#customize-message :submit", function(e){
     // Can't use rails remote: true because the form is rendered dynamically
     e.preventDefault();
+
+    var notice = $(this).parents('#customize-message').find('.notice');
+
+    if (notice.length && notice.hasClass('down')) {
+      var message = $('#message');
+      var offset = $('#customize-message .form-group')
+      if (message.val() == message.data('original-message')) {
+        return notice.removeClass('down');
+      }
+    }
+
+    notice.addClass('down');
+
     var $form = $("#congress-message-create");
     $.ajax({
       type: "POST",
@@ -80,6 +93,11 @@ $(document).on("ready", function() {
         }
       }
     });
+  });
+
+  $(".congress-message-tool-container").on("click", "#customize-message .notice .edit", function(e) {
+    e.preventDefault();
+    $('#customize-message .notice').addClass('down');
   });
 
   function show_progress_bars() {

--- a/app/assets/stylesheets/action_page.scss
+++ b/app/assets/stylesheets/action_page.scss
@@ -1254,3 +1254,84 @@ html.js #affiliations {
     }
   }
 }
+
+#congress-message-create {
+  position: relative;
+
+  #customize-message .notice {
+    overflow: hidden;
+    max-height: 25em;
+    transition: max-height 250ms linear, padding 250ms ease-in;
+
+    position: absolute;
+    bottom: 0;
+    padding: 1rem 2.5rem;
+    margin: 0 -.8rem -1rem;
+
+    @media (min-width: $md) {
+      margin-left: -2.3rem;
+    }
+
+    background-color: #e5e5e5;
+
+    font-size: .8em;
+
+    &.down {
+      padding-top: 0em;
+      padding-bottom: 0em;
+      max-height: 0em;
+    }
+  }
+
+  #customize-message .notice strong {
+    font-size: 1.2em;
+  }
+
+  #customize-message .notice p {
+    margin-top: 0.7em;
+  }
+
+  #customize-message .notice .actions {
+    display: flex;
+  }
+
+  #customize-message .notice input {
+    flex: 1;
+    padding: 0.4em;
+    margin: 0;
+    border: 0;
+
+    font-size: 1em;
+    font-weight: bold;
+
+    background: #c4c4c4;
+
+    &:first-child {
+      margin-right: 1rem;
+    }
+
+    &:not(:first-child) {
+      margin-left: 1rem;
+    }
+  }
+
+  #customize-message .notice .icon {
+    display: inline-block;
+    width: 1.3em;
+    height: 1.3em;
+    margin-right: 0.3em;
+
+    line-height: 1.3;
+    text-align: center;
+
+    border: 1px solid $eff-red;
+    border-radius: 50%;
+    background-color: $eff-red;
+
+    font-size: 1.3em;
+    color: #fff;
+
+    cursor: default;
+  }
+}
+

--- a/app/controllers/admin/action_pages_controller.rb
+++ b/app/controllers/admin/action_pages_controller.rb
@@ -204,7 +204,8 @@ class Admin::ActionPagesController < Admin::ApplicationController
         :id, :message, :subject, :target_house, :target_senate, { target_bioguide_list: [] },
         :topic_category_id, :alt_text_email_your_rep, :alt_text_look_up_your_rep,
         :alt_text_extra_fields_explain, :alt_text_look_up_helper,
-        :alt_text_customize_message_helper, :campaign_tag
+        :alt_text_customize_message_helper, :campaign_tag,
+        :enable_customization_notice
       ],
       partnerships_attributes: [:id, :enable_mailings]
     )

--- a/app/views/admin/action_pages/_congress_message_fields.html.erb
+++ b/app/views/admin/action_pages/_congress_message_fields.html.erb
@@ -41,4 +41,9 @@
     <%= sf.label :campaign_tag %>
     <%= sf.text_field :campaign_tag %>
   </div>
+
+  <div class="form-item">
+    <%= sf.label :enable_customization_notice %>
+    <%= sf.check_box :enable_customization_notice %>
+  </div>
 <% end %>

--- a/app/views/congress_messages/_form.html.erb
+++ b/app/views/congress_messages/_form.html.erb
@@ -75,14 +75,14 @@
     <fieldset>
       <h3>
         <span class="customize-message-popover" data-toggle="tooltip" data-trigger="hover">?
-          <span class="tooltiptext"><%= @campaign.look_up_helper_text "Add a personal note about why this matters to you. Members of Congress value a customized message much higher than a form letter." %></span>
+          <span class="tooltiptext">Congress values personalized letters! Add a note about why this issue matters to you.</span>
         </span>
-        Customize your message
+        Edit this message so that it is unique to you:
       </h3>
       <div class="form-group">
         <%= text_area_tag :message, @campaign.message,
           class: "campaign-message form-control",
-          rows: 11 %>
+          rows: 11, "data-original-message": @campaign.message %>
       </div>
       <%= render "tools/privacy_notice" %>
     </fieldset>
@@ -92,6 +92,15 @@
         <input type="submit" value="Test" name="test" class="eff-button test">
       <% end %>
     </div>
+    <% if @campaign.enable_customization_notice? %>
+      <div class="notice down">
+        <span class="icon">!</span> <strong>Did you personalize your letter?</strong>
+        <p>Add a personal note about why this issue matters to you. Members of Congress value unique, personal letters more highly than form ones.</p>
+        <div class="actions">
+          <input type="button" class="edit" value="Edit" /> <input type="submit" value="Send" />
+        </div>
+      </div>
+    <% end %>
     <%= render "tools/loading" -%>
   </div>
 <% end %>

--- a/db/migrate/20200324153626_add_enable_customization_notice_to_congress_message_campaigns.rb
+++ b/db/migrate/20200324153626_add_enable_customization_notice_to_congress_message_campaigns.rb
@@ -1,0 +1,5 @@
+class AddEnableCustomizationNoticeToCongressMessageCampaigns < ActiveRecord::Migration[5.0]
+  def change
+    add_column :congress_message_campaigns, :enable_customization_notice, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191031184958) do
+ActiveRecord::Schema.define(version: 20200324153626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -170,11 +170,11 @@ ActiveRecord::Schema.define(version: 20191031184958) do
   end
 
   create_table "congress_message_campaigns", force: :cascade do |t|
-    t.string   "subject",                                          null: false
-    t.text     "message",                                          null: false
-    t.string   "campaign_tag",                                     null: false
-    t.boolean  "target_house",                      default: true, null: false
-    t.boolean  "target_senate",                     default: true, null: false
+    t.string   "subject",                                           null: false
+    t.text     "message",                                           null: false
+    t.string   "campaign_tag",                                      null: false
+    t.boolean  "target_house",                      default: true,  null: false
+    t.boolean  "target_senate",                     default: true,  null: false
     t.string   "target_bioguide_ids"
     t.integer  "topic_category_id"
     t.string   "alt_text_email_your_rep"
@@ -182,8 +182,9 @@ ActiveRecord::Schema.define(version: 20191031184958) do
     t.string   "alt_text_extra_fields_explain"
     t.string   "alt_text_look_up_helper"
     t.string   "alt_text_customize_message_helper"
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
+    t.boolean  "enable_customization_notice",       default: false
   end
 
   create_table "congress_scorecards", force: :cascade do |t|


### PR DESCRIPTION
While putting this together I noticed that the margins and paddings inside the tool container are a little tricky to work with. I intend to circle back on that but am opening this PR now so that activism has this notice available for an upcoming campaign.

Two new shades of gray were in the mockup and are added here directly to the stylesheet. I considered adding them to _variables.scss but decided against it. IMO it's not worth it to try and name these colors, as we'll only end up with something like

```scss
$gray-especially-light: #edf1f4;
$gray-lighter: #e5e5e5;
$gray-light: #c4c4c4;
$gray: #BABABA;
$gray-dark: #999999;
$gray-darker: #949494;
$charcoal: #2D2D2D;
// etc
```
