### PR TITLE
Use TrueMail gem for email validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,10 @@ unthrottled_ips=
 # Analytics
 MATOMO_SITE_ID=
 
+# Truemail
+TRUEMAIL_VERIFY_EMAIL: editor@eff.org
+TRUEMAIL_VERIFY_DOMAIN: eff.org
+
 #
 # End of application environment variables
 #

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ gem "jbuilder", "~> 1.2" # JSON APIs
 gem "oauth", "~> 0"
 gem "rest-client", "~> 2"
 gem "sanitize", "~> 4" # Sanitize user input
+gem "truemail"
 gem "warden", "1.2.4" # This dep of devise has a bug in 1.2.5 so am avaoiding
 gem "whenever", "~> 0", require: false # Cron jobs
 gem "will_paginate", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,6 +431,8 @@ GEM
       rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (0.15.6)
       faraday (>= 0.7.6)
+    simpleidn (0.1.1)
+      unf (~> 0.1.4)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -445,6 +447,8 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    truemail (1.7.1)
+      simpleidn (~> 0.1.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -564,6 +568,7 @@ DEPENDENCIES
   selenium-webdriver (~> 3)
   sentry-raven (~> 0.15)
   sprockets-image_compressor (~> 0)
+  truemail
   uglifier (>= 1.3.0)
   warden (= 1.2.4)
   webdrivers (~> 4)
@@ -574,4 +579,4 @@ DEPENDENCIES
   xmlrpc
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/app/controllers/congress_messages_controller.rb
+++ b/app/controllers/congress_messages_controller.rb
@@ -91,7 +91,7 @@ class CongressMessagesController < ApplicationController
   end
 
   def subscribe_user
-    if params[:subscribe] == "1"
+    if params[:subscribe] == "1" && Truemail.valid?(user_params[:email])
       source = "action center congress message :: " + @action_page.title
       user = User.find_or_initialize_by(email: user_params[:email])
       user.attributes = user_params

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -9,7 +9,7 @@ class SubscriptionsController < ApplicationController
 
   def create
     email = params[:subscription][:email]
-    if !EmailValidator.valid?(email)
+    unless Truemail.valid?(email)
       render json: { message: "Bad news, something went wrong with your email address. Please check it for typos and try again." }, status: 400
       return
     end

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -50,8 +50,8 @@ class ToolsController < ApplicationController
   #
   # A form is posted here via ajax when a user signs a petition
   def petition
-    @user ||= User.find_or_initialize_by(email: params[:signature][:email])
     @email = params[:signature][:email]
+    @user ||= User.find_or_initialize_by(email: @email)
     @name = params[:signature][:first_name]
     @action_page = Petition.find(params[:signature][:petition_id]).action_page
     @signature = Signature.new(signature_params.merge(user_id: @user.id))
@@ -166,7 +166,7 @@ class ToolsController < ApplicationController
   end
 
   def create_newsletter_subscription
-    if params[:subscribe] && EmailValidator.valid?(params[:subscription][:email])
+    if params[:subscribe] && Truemail.valid?(params[:subscription][:email])
       source = "action center #{@action_page.class.name.downcase} :: " + @action_page.title
       params[:subscription][:opt_in] = true
       params[:subscription][:source] = source

--- a/config/initializers/truemail.rb
+++ b/config/initializers/truemail.rb
@@ -1,0 +1,71 @@
+require 'truemail'
+
+Truemail.configure do |config|
+  # Required parameter. Must be an existing email on behalf of which verification will be performed
+  config.verifier_email = ENV['TRUEMAIL_VERIFY_EMAIL']
+
+  # Optional parameter. Must be an existing domain on behalf of which verification will be performed.
+  # By default verifier domain based on verifier email
+  config.verifier_domain = ENV['TRUEMAIL_VERIFY_DOMAIN']
+
+  # Optional parameter. You can override default regex pattern
+  # config.email_pattern = /regex_pattern/
+
+  # Optional parameter. You can override default regex pattern
+  # config.smtp_error_body_pattern = /regex_pattern/
+
+  # Optional parameter. Connection timeout is equal to 2 ms by default.
+  # config.connection_timeout = 1
+
+  # Optional parameter. A SMTP server response timeout is equal to 2 ms by default.
+  # config.response_timeout = 1
+
+  # Optional parameter. Total of connection attempts. It is equal to 2 by default.
+  # This parameter uses in mx lookup timeout error and smtp request (for cases when
+  # there is one mx server).
+  # config.connection_attempts = 3
+
+  # Optional parameter. You can predefine default validation type for
+  # Truemail.validate('email@email.com') call without with-parameter
+  # Available validation types: :regex, :mx, :smtp
+  config.default_validation_type = :regex
+
+  # Optional parameter. You can predefine which type of validation will be used for domains.
+  # Also you can skip validation by domain. Available validation types: :regex, :mx, :smtp
+  # This configuration will be used over current or default validation type parameter
+  # All of validations for 'somedomain.com' will be processed with regex validation only.
+  # And all of validations for 'otherdomain.com' will be processed with mx validation only.
+  # It is equal to empty hash by default.
+  config.validation_type_for = { 'gmail.com' => :smtp, 'yahoo.com' => :smtp, 'aol.com' => :smtp }
+
+  # Optional parameter. Validation of email which contains whitelisted domain always will
+  # return true. Other validations will not processed even if it was defined in validation_type_for
+  # It is equal to empty array by default.
+  # config.whitelisted_domains = ['somedomain1.com', 'somedomain2.com']
+
+  # Optional parameter. With this option Truemail will validate email which contains whitelisted
+  # domain only, i.e. if domain whitelisted, validation will passed to Regex, MX or SMTP validators.
+  # Validation of email which not contains whitelisted domain always will return false.
+  # It is equal false by default.
+  # config.whitelist_validation = true
+
+  # Optional parameter. Validation of email which contains blacklisted domain always will
+  # return false. Other validations will not processed even if it was defined in validation_type_for
+  # It is equal to empty array by default.
+  # config.blacklisted_domains = ['somedomain1.com', 'somedomain2.com']
+
+  # Optional parameter. This option will provide to use not RFC MX lookup flow.
+  # It means that MX and Null MX records will be cheked on the DNS validation layer only.
+  # By default this option is disabled.
+  # config.not_rfc_mx_lookup_flow = true
+
+  # Optional parameter. This option will be parse bodies of SMTP errors. It will be helpful
+  # if SMTP server does not return an exact answer that the email does not exist
+  # By default this option is disabled, available for SMTP validation only.
+  # config.smtp_safe_check = true
+
+  # Optional parameter. This option will enable tracking events. You can print tracking events to
+  # stdout, write to file or both of these. Tracking event by default is :error
+  # Available tracking event: :all, :unrecognized_error, :recognized_error, :error
+  # config.logger = { tracking_event: :all, stdout: true, log_absolute_path: '/home/app/log/truemail.log' }
+end


### PR DESCRIPTION
Implements the Ruby TrueMail gem (https://github.com/rubygarage/truemail) to better filter out invalid email addresses.

New:
* Adds email validation check to Congress form flow
* New env vars & initializer for TrueMail

Changed:
* Replaced controller calls to `EmailValidator.valid?` with `Truemail.valid?`

Things to consider:
* Additional web request made to validate email address in the scope of a web request. Moving subscriptions to a background job might be better overall.
* Dynamic configuration of backlisted email domains and domains for SMTP checking
* Better form feedback for invalid emails