### PR TITLE
Change URL param for twitter web intent

### DIFF
--- a/app/helpers/action_page_helper.rb
+++ b/app/helpers/action_page_helper.rb
@@ -11,14 +11,14 @@ module ActionPageHelper
 
     related = Rails.application.config.twitter_related.to_a.join(",")
 
-    "https://twitter.com/intent/tweet?status=#{u message}&related=#{related}"
+    "https://twitter.com/intent/tweet?text=#{u message}&related=#{related}"
   end
 
 
   def tweet_url(target, message)
     message = [target, message].compact.join(" ")
     related = Rails.application.config.twitter_related.to_a.join(",")
-    "https://twitter.com/intent/tweet?status=.#{u message}&related=#{related}"
+    "https://twitter.com/intent/tweet?text=.#{u message}&related=#{related}"
   end
 
   def facebook_share_url(action_page)

--- a/app/views/tools/_tweet.html.erb
+++ b/app/views/tools/_tweet.html.erb
@@ -19,7 +19,13 @@
                 <img src="<%= target.image_url %>" class="individual">
               <% end %>
 
-              <%= link_to "https://twitter.com/intent/tweet?" + {status: ".@#{target.twitter_id} #{@tweet.message}", related: Rails.application.config.twitter_related.to_a.join(',')}.to_query, :target => "_blank", :class => "btn btn-default btn-tweet individual", :"data-twitter-id" => "@#{target.twitter_id}" do %>
+              <%= link_to "https://twitter.com/intent/tweet?" + {
+                  text: ".@#{target.twitter_id} #{@tweet.message}",
+                  related: Rails.application.config.twitter_related.to_a.join(',')
+                }.to_query,
+                  :target => "_blank",
+                  :class => "btn btn-default btn-tweet individual",
+                  :"data-twitter-id" => "@#{target.twitter_id}" do %>
                 <i class="icon-twitter-1"></i> Tweet <%= target.twitter_id %>
               <% end %>
             </div>


### PR DESCRIPTION
https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/guides/web-intent

Twitter Web Intent docs don't list a `status` parameter, changing it to `text` instead.