### PR TITLE
Don't automatically opt-in congress form subscribers

### DIFF
--- a/app/controllers/congress_messages_controller.rb
+++ b/app/controllers/congress_messages_controller.rb
@@ -95,7 +95,7 @@ class CongressMessagesController < ApplicationController
       source = "action center congress message :: " + @action_page.title
       user = User.find_or_initialize_by(email: user_params[:email])
       user.attributes = user_params
-      user.subscribe!(opt_in = true, source = source)
+      user.subscribe!(false, source)
     end
     create_partner_subscription
   end


### PR DESCRIPTION
Setting this to false should no longer bypass CiviCRM's Double-opt-in.