### PR TITLE
Add period before twitter mention

### DIFF
--- a/app/assets/javascripts/application/tools/tweet.js
+++ b/app/assets/javascripts/application/tools/tweet.js
@@ -67,7 +67,10 @@ $(document).on('ready', function() {
     var msg = $('#tweet-message-wrapper textarea');
     if (msg.length > 0) {
       btn.attr('href', "https://twitter.com/intent/tweet?related=eff&text=" +
-               btn.data('twitter-id') + "%20" + encodeURIComponent(msg.val()));
+               "." +
+               btn.data('twitter-id') +
+               "%20" +
+               encodeURIComponent(msg.val()));
     }
     Twitter.handleIntent(e);
     $('#tweet-tool').hide();

--- a/app/views/tools/_tweet.html.erb
+++ b/app/views/tools/_tweet.html.erb
@@ -26,7 +26,7 @@
                   :target => "_blank",
                   :class => "btn btn-default btn-tweet individual",
                   :"data-twitter-id" => "@#{target.twitter_id}" do %>
-                <i class="icon-twitter-1"></i> Tweet <%= target.twitter_id %>
+                <i class="icon-twitter-1"></i> Tweet @<%= target.twitter_id %>
               <% end %>
             </div>
           <% end %>


### PR DESCRIPTION
Fixes the following:

* When using a Tweet action, the leading period before a mention isn't added to the intent URL in the custom JS
* Individuals on the Tweet button are missing their @ while representatives have them