### PR TITLE
Fix signature cleanup task; add validations to prevent duplicates

### DIFF
--- a/app/controllers/concerns/tooling.rb
+++ b/app/controllers/concerns/tooling.rb
@@ -7,7 +7,7 @@ module Tooling
     return unless @action_page
     @action_page.partners.each do |partner|
       if params["#{partner.code}_subscribe"] == "1"
-        Subscription.create!(partner_signup_params.merge(partner: partner))
+        Subscription.create(partner_signup_params.merge(partner: partner))
       end
     end
   end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -13,6 +13,8 @@ class Signature < ActiveRecord::Base
   validates_presence_of :country_code, if: :location_required?
 
   validates :email, email: true
+  validates :email, uniqueness: { scope: :petition_id,
+                                  message: "You've already signed this petition!" }
   validates :zipcode, length: { maximum: 12 }
   validate :country_code, :arbitrary_opinion_of_country_string_validity
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,4 +1,5 @@
 class Subscription < ActiveRecord::Base
   belongs_to :partner, counter_cache: true
   validates :email, presence: true, email: true
+  validates :email, uniqueness: { scope: :partner_id }
 end

--- a/docker/crontab
+++ b/docker/crontab
@@ -1,4 +1,3 @@
-0 * * * * root su -s/bin/bash www-data -c '. /var/www/.profile && cd /opt/actioncenter && bundle exec rake signatures:deduplicate' >>/proc/1/fd/1 2>&1
 0 0 * * * root su -s/bin/bash www-data -c '. /var/www/.profile && cd /opt/actioncenter && bundle exec rake congress:update'        >>/proc/1/fd/1 2>&1
 0 0 * * * root su -s/bin/bash www-data -c '. /var/www/.profile && cd /opt/actioncenter && bundle exec rake db:sessions:trim'        >>/proc/1/fd/1 2>&1
 

--- a/spec/controllers/admin/petitions_controller_spec.rb
+++ b/spec/controllers/admin/petitions_controller_spec.rb
@@ -34,19 +34,7 @@ RSpec.describe Admin::PetitionsController, type: :controller do
   describe "DELETE #destroy_signatures" do
     let(:petition) { FactoryGirl.create(:petition) }
     let(:signatures) do
-      30.times.map do
-        petition.signatures.create(
-          first_name: "Save Kittens",
-          last_name: "Save kittens in great detail",
-          email: "johnsmith@eff.org",
-          country_code: "US",
-          zipcode: "94109",
-          street_address: "815 Eddy Street",
-          city: "San Francisco",
-          state: "CA",
-          anonymous: false
-        )
-      end
+      30.times.map { FactoryGirl.create(:signature, petition: petition) }
     end
 
     it "should delete signatures from the signature_ids param" do

--- a/spec/tasks/signatures_spec.rb
+++ b/spec/tasks/signatures_spec.rb
@@ -41,7 +41,8 @@ describe "signatures namespace rake tasks" do
         FactoryGirl.create(:subscription, partner: partner)
       end
       let!(:dup_subscription) do
-        FactoryGirl.create(:subscription, email: email, partner: partner)
+        FactoryGirl.create(:subscription)
+                   .update_columns(email: email, partner_id: partner.id)
       end
 
       it "removes the newer duplicates" do


### PR DESCRIPTION
It turns out that this task has been broken for a long time because signatures/subscriptions ids weren't included in the group clause. This is maybe breaking staging at the moment.