### PR TITLE
Add left padding to tool notice 

### DIFF
--- a/app/assets/stylesheets/action_page.scss
+++ b/app/assets/stylesheets/action_page.scss
@@ -261,6 +261,7 @@
     }
     .tool-notice {
       padding-bottom: 0.5rem;
+      padding-left: 1rem;
     }
     .btn-default[disabled="disabled"] {
       opacity: 0.7;


### PR DESCRIPTION
Adds Left padding to tool notice to fix the alignment. Fix #807 