### PR TITLE
fix feature specs

### DIFF
--- a/spec/features/action_pages/state_leg_email_action_spec.rb
+++ b/spec/features/action_pages/state_leg_email_action_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature "State legislator email actions", type: :feature, js: true do
     Rails.application.secrets.google_civic_api_key = "test-key-for-civic-api"
 
     stub_request(:get, "http://civic.example.com/?address=815%20Eddy%20St%2094109&includeOffices=true&key=test-key-for-civic-api&levels=administrativeArea1&roles=legislatorUpperBody")
-      .with(headers: { "Accept" => "*/*", "Accept-Encoding" => "gzip, deflate", "Host" => "civic.example.com", "User-Agent" => "rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157" })
       .to_return(status: 200, body: json_parseable_state_officials, headers: {})
   end
 

--- a/spec/features/admin/action_creation_spec.rb
+++ b/spec/features/admin/action_creation_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe "Admin action page creation", type: :feature, js: true do
     fill_in "Message", with: "A message"
     next_section
 
-    # skip banner selection
-    next_section
-
+    skip_banner_selection
     fill_in_social_media
 
     tempermental do
@@ -38,9 +36,7 @@ RSpec.describe "Admin action page creation", type: :feature, js: true do
     fill_in "Goal", with: 1000
     next_section
 
-    # skip banner selection
-    next_section
-
+    skip_banner_selection
     fill_in_social_media
 
     tempermental do
@@ -59,14 +55,10 @@ RSpec.describe "Admin action page creation", type: :feature, js: true do
     select_action_type("email")
     fill_in "Subject", with: "Subject"
     fill_in "Message", with: "An email"
-    next_section
-
-    # skip banner selection
-    next_section
     fill_in "Or enter custom email addresses below:", with: "test@gmail.com"
-    click_on "Next"
     next_section
 
+    skip_banner_selection
     fill_in_social_media
 
     tempermental do
@@ -91,10 +83,8 @@ RSpec.describe "Admin action page creation", type: :feature, js: true do
 
     click_on "Next"
 
-    skip_image_selection
+    skip_banner_selection
     fill_in_social_media
-    # Skip partners
-    click_on "Next"
 
     tempermental do
       click_button "Save"
@@ -114,9 +104,7 @@ RSpec.describe "Admin action page creation", type: :feature, js: true do
     fill_in "Message", with: "A message"
     next_section
 
-    # skip banner selection
-    next_section
-
+    skip_banner_selection
     fill_in_social_media
 
     tempermental do
@@ -137,9 +125,7 @@ RSpec.describe "Admin action page creation", type: :feature, js: true do
                    with: "Call script"
     next_section
 
-    # skip banner selection
-    next_section
-
+    skip_banner_selection
     fill_in_social_media
 
     tempermental do
@@ -152,7 +138,7 @@ RSpec.describe "Admin action page creation", type: :feature, js: true do
     fill_in "Title", with: title
     fill_in_editor "#action_page_summary", with: summary
     fill_in_editor "#action_page_description", with: description
-    fill_in_select2 "#action_page_category_id", with: category.title
+    select(category.title, from: "action_page_category_id") #we should use the label to find the select but the label here is not correctly pointing to the select
   end
 
   def next_section
@@ -160,7 +146,13 @@ RSpec.describe "Admin action page creation", type: :feature, js: true do
     sleep 0.05
   end
 
+  def skip_banner_selection
+    expect(page).to have_selector("#images", visible: true, wait: 5)
+    next_section
+  end
+
   def fill_in_social_media
+    expect(page).to have_selector("#sharing", visible: true, wait: 5)
     fill_in "Share Message", with: "Twitter message"
     fill_in "Title", with: "A social media title"
     next_section

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,9 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
 
+  # Filter lines from Rails gems in backtraces.
+  config.filter_rails_from_backtrace!
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.
@@ -64,7 +67,7 @@ RSpec.configure do |config|
   config.before(:each) { DatabaseCleaner.strategy = :transaction }
   config.before(:each, js: true) { DatabaseCleaner.strategy = :truncation }
   config.before(:each) { DatabaseCleaner.start }
-  config.after(:each) { DatabaseCleaner.clean }
+  config.append_after(:each) { DatabaseCleaner.clean }
 
   config.before(:each, type: :feature) do
     # disable call tool by default; it will be stubbed for tests that need it

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,7 @@ ActiveRecord::Migration.maintain_test_schema!
 Capybara.server = :puma
 Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.enable_aria_label = true
+Capybara.disable_animation = true
 
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller


### PR DESCRIPTION
This change to database cleaner config fixed a failing testing in features/action_pages/call_action_spec for me.

We should consider removing it as DatabaseCleaner is not usually necessary in new rails versions.