### PR TITLE
Scrub potetially sensitive info before sending to Sentry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,9 @@ fastly_api_key=
 
 # Error reporting (not required, leave empty to prevent sentry from sending events)
 sentry_dsn=
+SENTRY_ENVIRONMENT=
+SENTRY_TRACES_SAMPLE_RATE=
+SENTRY_PROFILES_SAMPLE_RATE=
 
 # Miscellaneous (not required)
 SESSION_DAYS_TRIM_THRESHOLD=365

--- a/app/controllers/sns_controller.rb
+++ b/app/controllers/sns_controller.rb
@@ -40,10 +40,6 @@ class SnsController < ApplicationController
 
   def log_request
     logger.info "Received Amazon SES #{action_name} notification"
-    Sentry.with_scope do |scope|
-      scope.set_extras(message: request.body.read)
-      Sentry.capture_message("Received Amazon SES #{action_name} notification", level: "info")
-    end
-    request.body.rewind
+    Sentry.capture_message("Received Amazon SES #{action_name} notification", level: "info")
   end
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,27 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :email, :first_name, :last_name, :zipcode, :street, :city, :state, :country_code, :phone, :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn]
+Rails.application.config.filter_parameters += [
+    :password,
+    :email,
+    :first_name,
+    /name_first/i,
+    /name_last/i,
+    :last_name,
+    # :zipcode,
+    :street,
+    :city,
+    :state,
+    :country_code,
+    :phone,
+    :passw,
+    :secret,
+    :token,
+    :_key,
+    :crypt,
+    :salt,
+    :certificate,
+    :otp,
+    :ssn,
+    /\$?message/i,
+]

--- a/config/initializers/rack_attack_logger.rb
+++ b/config/initializers/rack_attack_logger.rb
@@ -4,6 +4,6 @@ ActiveSupport::Notifications.subscribe('rack.attack') do |name, start, finish, r
   else
     ip = req.ip
   end
-  message = "Rate limit exceeded on #{req.fullpath}"
+  message = "Rate limit exceeded on #{URI(req.fullpath).path}" # Drop query params, which may be sensitive
   Sentry.capture_message(message, extra: { ip: ip })
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,9 +1,73 @@
+# frozen_string_literal: true
+
+require "active_support/parameter_filter"
+
+# https://docs.sentry.io/platforms/ruby/configuration/options/
 Sentry.init do |config|
   config.dsn = Rails.application.secrets.sentry_dsn
   # get breadcrumbs from logs
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
-  # enable tracing
-  # we recommend adjusting this value in production
-  config.traces_sample_rate = 1.0
+  config.environment = ENV['SENTRY_ENVIRONMENT']
+
+  config.send_default_pii = false
+
+  config.before_breadcrumb = lambda do |breadcrumb, hint|
+    # Remove query params from path in request breadcrumbs, since they can share sensitive info like addresses
+    if hint.dig('request').present?
+      breadcrumb.path = begin
+        url = URI.parse(breadcrumb.path)
+        url.query = nil
+        url.to_s
+      rescue URI::Error
+        url.split("?").first
+      end
+    end
+    breadcrumb
+  end
+
+  # Filter out potentially sensitive data before sending to Sentry.io
+  # This applies any filters we've set to logs to also apply to Sentry data
+  #
+  # https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/
+  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+  config.before_send = lambda do |event, _hint|
+    # Sanitize extra data
+    if event.extra
+      event.extra = filter.filter(event.extra)
+    end
+    # Sanitize user data
+    if event.user
+      event.user = filter.filter(event.user)
+    end
+    # Sanitize context data (if present)
+    if event.contexts
+      event.contexts = filter.filter(event.contexts)
+    end
+
+    # Return the sanitized event object
+    event
+  end
+
+  # https://docs.sentry.io/platforms/ruby/configuration/sampling/
+  # A sample rate of 0 or false sends nothing, 1.0 or true sends everything
+  config.traces_sampler = lambda do |sampling_context|
+    # if this is the continuation of a trace, just use that decision (rate controlled by the caller)
+    unless sampling_context[:parent_sampled].nil?
+      next sampling_context[:parent_sampled]
+    end
+
+    # /heartbeat
+    if sampling_context.dig(:env, 'HTTP_USER_AGENT') =~ (/healthcheck/i) || sampling_context.dig(:env, 'PATH_INFO') =~ (/heartbeat/i)
+      0.0
+    else
+      begin ENV['SENTRY_TRACES_SAMPLE_RATE'].to_f rescue 0.0 end
+    end
+  end
+
+  # Set profiles_sample_rate to profile 100% of sampled transactions.
+  # We recommend adjusting this value in production.
+  #
+  # Does not send profiling info if set to 0
+  config.profiles_sample_rate = begin ENV['SENTRY_PROFILES_SAMPLE_RATE'].to_f rescue 0 end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -72,6 +72,7 @@ test:
   congress_forms_url: "https://congressforms.eff.org"
   congress_forms_debug_key: "shh"
   fastly_api_key:
+  sentry_dsn: ''
 
 production: *default
 staging: *default


### PR DESCRIPTION
Since we intend to send exception, trace, and breadcrumb info to a third-party Sentry, we now need to scrub potentially sensitive info before sending.

This commit attempts to remove where we've seen it, including:
* from where we were intentionally sending addtiional data with exceptions
* removing from breadcrumbs and traces via the Rails filter_parameters, which uses regexes to filter data from appearing in logs
* dropping query params from the path in action-controller breadcrumbs, since it was showing get params that could reveal address information.

More might be needed