### PR TITLE
Fix docker build after explicitly requiring fiddle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
     cron \
     gnupg \
     libssl-dev \
+    libffi-dev \
     shared-mime-info \
     nodejs \
     npm


### PR DESCRIPTION
Added fiddle to the gemfile to silence a warning about its upcoming removal from stdlib, broke the dockerfile; this fixes it.