### PR TITLE
amazon_bucket_url accepts both https:// and non-http prefixed URLs

### DIFF
--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -39,7 +39,9 @@ class SourceFile < ApplicationRecord
   def full_url
     # if we have a custom amazon_bucket_url...
     if ENV["amazon_bucket_url"]
-      "https://#{ENV['amazon_bucket_url']}/#{key}"
+      # make sure there's a scheme prefixed (http, https)
+      base_url = URI.parse(ENV['amazon_bucket_url']).scheme ? ENV['amazon_bucket_url'] : "https://#{ENV['amazon_bucket_url']}"
+      URI.join(base_url, key)
     else # we have to build the url up from amazon information
       "https://#{ENV['amazon_bucket']}.s3-#{Rails.application.secrets.amazon_region}.amazonaws.com/#{key}"
     end


### PR DESCRIPTION
Makes this a little bit more flexible since we ran into an issue with expecting there to _not_ be an https prefix on the URL when moving to use Digital Ocean, which seems a bit counterintuitive.