### PR TITLE
Expect S3 bucket urls to include https://

### DIFF
--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -39,8 +39,7 @@ class SourceFile < ApplicationRecord
   def full_url
     # if we have a custom amazon_bucket_url...
     if ENV["amazon_bucket_url"]
-      # make sure there's a scheme prefixed (http, https)
-      base_url = URI.parse(ENV['amazon_bucket_url']).scheme ? ENV['amazon_bucket_url'] : "https://#{ENV['amazon_bucket_url']}"
+      base_url = URI.parse(ENV["amazon_bucket_url"])
       URI.join(base_url, key).to_s
     else # we have to build the url up from amazon information
       "https://#{ENV['amazon_bucket']}.s3-#{Rails.application.secrets.amazon_region}.amazonaws.com/#{key}"

--- a/app/uploaders/action_page_image_uploader.rb
+++ b/app/uploaders/action_page_image_uploader.rb
@@ -10,11 +10,6 @@ class ActionPageImageUploader < CarrierWave::Uploader::Base
     "#{model.class.to_s.pluralize.underscore}/#{mounted_as.to_s.pluralize}/#{id_partition}/#{style}"
   end
 
-  # we could set this here or config/initializers/carrier_wave.rb
-  def asset_host
-    Rails.application.secrets.amazon_bucket_url.present? ? "https://#{Rails.application.secrets.amazon_bucket_url}" : super
-  end
-
   private
 
   def style

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -20,7 +20,7 @@ CarrierWave.configure do |config|
   # Use this if you have Google Cloud Storage uniform bucket-level access enabled.
   # config.fog_attributes = { uniform: true }
   # Use if you use a CDN
-  # config.asset_host = "http://mycdn.cdn.com"
+  config.asset_host = Rails.application.secrets.amazon_bucket_url if Rails.application.secrets.amazon_bucket_url.present?
   # setting here allows you to setup a local dev env that points to production assets if `amazon_bucket_url` doesnt match the bucket other things will break
   # config.asset_host = Rails.application.secrets.amazon_bucket_url.present? ? "https://#{Rails.application.secrets.amazon_bucket_url}" : nil
   # For an application which utilizes multiple servers but does not need caches persisted across requests,

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 describe SourceFile do
-  before(:each) do
+  before do
     @source_file = FactoryBot.create(:source_file, key: "meh.jpg")
   end
 
   it "should generate full_urls correctly when amazon_bucket_url is set" do
-    bucket_url = ENV["amazon_bucket_url"] = "act.s.eff.org"
-    expect(@source_file.full_url).to eq "https://#{bucket_url}/meh.jpg"
+    bucket_url = ENV["amazon_bucket_url"] = "https://act.s.eff.org"
+    expect(@source_file.full_url).to eq "#{bucket_url}/meh.jpg"
   end
 
   it "should generate full_urls correctly when amazon_bucket_url is not set based on region" do


### PR DESCRIPTION
#935 allowed us to support ENV variables with or without the scheme, but we also have to set the bucket for carrierwave. The initializer in `config/initializers/aws.rb` expects that the endpoint includes the scheme, so I think we should just include it in the environment variables moving forward.