### PR TITLE
Remove the .html in render, bc it was causing exceptions app to error

### DIFF
--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -9,7 +9,7 @@ class ExceptionsController < ActionController::Base
     respond_to do |format|
       format.xml  { render xml: details, root: "error", status: @status_code }
       format.json { render json: { error: details }, status: @status_code }
-      format.any { render "show.html", status: @status_code, layout: !request.xhr?, content_type: "text/html" }
+      format.any { render "show", status: @status_code, layout: !request.xhr?, content_type: "text/html" }
     end
   end
 


### PR DESCRIPTION
Trying to address this error, happening on exception in staging env:
```
Error during failsafe response: Missing template exceptions/show.html with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}.

Searched in:
  * "/opt/actioncenter/app/views"
```

I believe the .html is throwing off the filename lookup, since the actual file is `/opt/actioncenter/app/views/exceptions/show.html.erb`