### PR TITLE
Fix tweet targets page

### DIFF
--- a/app/views/tools/_tweet.html.erb
+++ b/app/views/tools/_tweet.html.erb
@@ -1,5 +1,5 @@
 <div class="tool <%= tweet_tool_classes -%>" id="tweet-tool"
-     data-tweet-targets="<%= @tweet.targets.to_json(only: :twitter_id, methods: :image_url) %>"
+     data-tweet-targets="<%= @tweet.targets.to_json(only: :twitter_id) %>"
      data-tweet-message="<%= @tweet.message %>"
      data-tweet-related="<%= Rails.application.config.twitter_related.to_a.join(",") %>">
   <div class="tool-container">


### PR DESCRIPTION
When we removed support for paperclip / images on tweets, we missed this line. As a result it was breaking the tweet target page.

Original commit: 89eed8b6ff094f9b60f5a525eec69d6aad2c1902
Context in issue: github.com/EFForg/action-center-platform/issues/913#issuecomment-2062004236

Confirmed this fix works locally.