### PR TITLE
Delete public user accounts

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -48,4 +48,16 @@ namespace :users do
       puts "Granting admin status to #{email} failed."
     end
   end
+
+  desc "Delete non-admins"
+  task delete_nonadmins: :environment do |_t, args|
+    delete_count = User.where(admin: false).count
+    retain_count = User.where(admin: true).count
+    puts "#{Time.now}: Deleting #{delete_count} non-admin user accounts. Retaining #{retain_count} admin accounts."
+    User.where(admin: false).in_batches.each_with_index do |batch, batch_index|
+      puts "#{Time.now}: Processing batch #{batch_index}"
+      batch.delete_all
+    end
+    puts "#{Time.now}: Deletion complete"
+  end
 end


### PR DESCRIPTION
But keep the admins. 

`.delete_all` [intentionally skips activemodel callbacks](https://api.rubyonrails.org/v8.1.2/classes/ActiveRecord/Relation.html#method-i-delete_all)

I tested this locally on small set of test data. Would appreciate a lookover to make sure:
1.  there aren't any other accounts we should exclude from deletion
2. confirm we _shouldn't_ run callbacks on deletion (I skipped them because it felt too risky/destructive)
3. any other gotchas I'm missing

Task can be ran as `bin/rake users:delete_nonadmins`